### PR TITLE
bugfix: network table not refreshing after remove

### DIFF
--- a/ui/networks/commands.go
+++ b/ui/networks/commands.go
@@ -102,6 +102,7 @@ func (nets *Networks) remove() {
 			nets.errorDialog.Display()
 			return
 		}
+		nets.UpdateData()
 	}
 	go remove(nets.selectedID)
 }


### PR DESCRIPTION
Network table list is not refreshing after newtork removal.
Podman system events doesn't include network events, therefore after network removal we need to query and update the table data.

Signed-off-by: Navid Yaghoobi <n.yaghoobi.s@gmail.com>