### PR TITLE
remove volume destination field from container create dialog

### DIFF
--- a/pdcs/containers/create.go
+++ b/pdcs/containers/create.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/containers/podman-tui/pdcs/connection"
+	"github.com/containers/podman-tui/pdcs/volumes"
 )
 
 //CreateOptions container create options.
@@ -30,7 +31,6 @@ type CreateOptions struct {
 	DNSOptions      []string
 	DNSSearchDomain []string
 	Volume          string
-	VolumeDest      string
 	ImageVolume     string
 }
 
@@ -109,9 +109,14 @@ func Create(opts CreateOptions) ([]string, error) {
 		containerSpecGen.ImageVolumeMode = opts.ImageVolume
 	}
 	if opts.Volume != "" {
+		// get volumes dest
+		volumeDest, err := volumes.VolumeDest(opts.Volume)
+		if err != nil {
+			return warningResponse, err
+		}
 		containerSpecGen.Volumes = append(containerSpecGen.Volumes, &specgen.NamedVolume{
 			Name: opts.Volume,
-			Dest: opts.VolumeDest,
+			Dest: volumeDest,
 		})
 	}
 

--- a/pdcs/volumes/utils.go
+++ b/pdcs/volumes/utils.go
@@ -1,0 +1,36 @@
+package volumes
+
+import (
+	"fmt"
+
+	"github.com/containers/podman-tui/pdcs/connection"
+	"github.com/containers/podman/v3/pkg/bindings/volumes"
+	"github.com/rs/zerolog/log"
+)
+
+// VolumeDest returns a volume destination (mountpoint) path
+func VolumeDest(name string) (string, error) {
+	log.Debug().Msgf("pdcs: podman volume destination query: %s", name)
+	var dest string
+	conn, err := connection.GetConnection()
+	if err != nil {
+		return dest, err
+	}
+	queryFilter := make(map[string][]string)
+	queryFilter["name"] = []string{
+		name,
+	}
+	response, err := volumes.List(conn, new(volumes.ListOptions).WithFilters(queryFilter))
+	if err != nil {
+		return dest, err
+	}
+	for _, resp := range response {
+		if resp.Name == name {
+			dest = resp.Mountpoint
+		}
+	}
+	if dest == "" {
+		return "", fmt.Errorf("volume destination cannot be empty")
+	}
+	return dest, nil
+}

--- a/ui/containers/cntdialogs/create.go
+++ b/ui/containers/cntdialogs/create.go
@@ -43,7 +43,6 @@ const (
 	createContainerDNSSearchFieldFocus
 	createContainerImageVolumeFieldFocus
 	createContainerVolumeFieldFocus
-	createContainerVolumeDestFocus
 )
 
 const (
@@ -88,7 +87,6 @@ type ContainerCreateDialog struct {
 	containerDNSOptionsField     *tview.InputField
 	containerDNSSearchField      *tview.InputField
 	containerVolumeField         *tview.DropDown
-	containerVolumeDestField     *tview.InputField
 	containerImageVolumeField    *tview.DropDown
 	cancelHandler                func()
 	createHandler                func()
@@ -126,7 +124,6 @@ func NewContainerCreateDialog() *ContainerCreateDialog {
 		containerDNSOptionsField:     tview.NewInputField(),
 		containerDNSSearchField:      tview.NewInputField(),
 		containerVolumeField:         tview.NewDropDown(),
-		containerVolumeDestField:     tview.NewInputField(),
 		containerImageVolumeField:    tview.NewDropDown(),
 	}
 
@@ -235,12 +232,6 @@ func NewContainerCreateDialog() *ContainerCreateDialog {
 	containerDialog.containerVolumeField.SetBackgroundColor(bgColor)
 	containerDialog.containerVolumeField.SetLabelColor(tcell.ColorWhite)
 
-	// volume
-	containerDialog.containerVolumeDestField.SetLabel("Volume Dest:")
-	containerDialog.containerVolumeDestField.SetLabelWidth(volumePageLabelWidth)
-	containerDialog.containerVolumeDestField.SetBackgroundColor(bgColor)
-	containerDialog.containerVolumeDestField.SetLabelColor(tcell.ColorWhite)
-
 	// image volume
 	containerDialog.containerImageVolumeField.SetLabel("Image volume:")
 	containerDialog.containerImageVolumeField.SetLabelWidth(volumePageLabelWidth)
@@ -322,8 +313,6 @@ func (d *ContainerCreateDialog) setupLayout() {
 	// volume settigs page
 	d.volumePage.SetDirection(tview.FlexRow)
 	d.volumePage.AddItem(d.containerVolumeField, 1, 0, true)
-	d.volumePage.AddItem(emptySpace(), 1, 0, true)
-	d.volumePage.AddItem(d.containerVolumeDestField, 1, 0, true)
 	d.volumePage.AddItem(emptySpace(), 1, 0, true)
 	d.volumePage.AddItem(d.containerImageVolumeField, 1, 0, true)
 	d.volumePage.SetBackgroundColor(bgColor)
@@ -447,8 +436,6 @@ func (d *ContainerCreateDialog) Focus(delegate func(p tview.Primitive)) {
 	// volume page
 	case createContainerVolumeFieldFocus:
 		delegate(d.containerVolumeField)
-	case createContainerVolumeDestFocus:
-		delegate(d.containerVolumeDestField)
 	case createContainerImageVolumeFieldFocus:
 		delegate(d.containerImageVolumeField)
 	// category page
@@ -671,7 +658,6 @@ func (d *ContainerCreateDialog) initData() {
 	d.containerNetworkField.SetCurrentOption(0)
 	d.containerVolumeField.SetOptions(volumeOptions, nil)
 	d.containerVolumeField.SetCurrentOption(0)
-	d.containerVolumeDestField.SetText("")
 	d.containerImageVolumeField.SetOptions(imageVolumeOptions, nil)
 	d.containerImageVolumeField.SetCurrentOption(0)
 }
@@ -724,8 +710,6 @@ func (d *ContainerCreateDialog) setDNSSettingsPageNextFocus() {
 
 func (d *ContainerCreateDialog) setVolumeSettingsPageNextFocus() {
 	if d.containerVolumeField.HasFocus() {
-		d.focusElement = createContainerVolumeDestFocus
-	} else if d.containerVolumeDestField.HasFocus() {
 		d.focusElement = createContainerImageVolumeFieldFocus
 	} else {
 		d.focusElement = createFormFocus
@@ -816,7 +800,6 @@ func (d *ContainerCreateDialog) ContainerCreateOptions() containers.CreateOption
 		DNSOptions:      dnsOptions,
 		DNSSearchDomain: dnsSearchDomains,
 		Volume:          volume,
-		VolumeDest:      d.containerVolumeDestField.GetText(),
 		ImageVolume:     imageVolume,
 	}
 	return opts


### PR DESCRIPTION
Container create dialog does not require "volume destination" field and this need to be resolve automatically.

Signed-off-by: Navid Yaghoobi <n.yaghoobi.s@gmail.com>