### PR TITLE
tests update: udpate wait time + command index for container and pod

### DIFF
--- a/test/004-pod.bats
+++ b/test/004-pod.bats
@@ -45,7 +45,7 @@ load helpers_tui
     podman_tui_set_view "pods"
     podman_tui_select_item $pod_index
     podman_tui_select_pod_cmd "start"
-    sleep 1
+    sleep 2
 
     run_podman pod ls --filter="name=$TEST_POD_NAME" --format "'{{ .Status}}'"
     assert $output =~ "Running" "expected $TEST_POD_NAME running"
@@ -60,7 +60,7 @@ load helpers_tui
     podman_tui_set_view "pods"
     podman_tui_select_item $pod_index
     podman_tui_select_pod_cmd "pause"
-    sleep 1
+    sleep 2
 
     run_podman pod ls --filter="name=$TEST_POD_NAME" --format "'{{ .Status}}'"
     assert $output =~ "Paused" "expected $TEST_POD_NAME running"
@@ -75,7 +75,7 @@ load helpers_tui
     podman_tui_set_view "pods"
     podman_tui_select_item $pod_index
     podman_tui_select_pod_cmd "unpause"
-    sleep 1
+    sleep 2
 
     run_podman pod ls --filter="name=$TEST_POD_NAME" --format "'{{ .Status}}'"
     assert $output =~ "Running" "expected $TEST_POD_NAME running"
@@ -90,7 +90,7 @@ load helpers_tui
     podman_tui_set_view "pods"
     podman_tui_select_item $pod_index
     podman_tui_select_pod_cmd "stop"
-    sleep 1
+    sleep 2
 
     run_podman pod ls --filter="name=$TEST_POD_NAME" --format "'{{ .Status}}'"
     assert $output =~ "Exited" "expected $TEST_POD_NAME exited"
@@ -120,7 +120,7 @@ load helpers_tui
     podman_tui_set_view "pods"
     podman_tui_select_item $pod_index
     podman_tui_select_pod_cmd "kill"
-    sleep 1
+    sleep 2
 
     run_podman pod ls --filter="name=$TEST_POD_NAME" --format "'{{ .Status}}'"
     assert $output =~ "Exited" "expected $TEST_POD_NAME exited"
@@ -136,7 +136,7 @@ load helpers_tui
     podman_tui_set_view "pods"
     podman_tui_select_item $pod_index
     podman_tui_select_pod_cmd "inspect"
-    sleep 1
+    sleep 2
     podman_tui_send_inputs "Enter"
 
     run_helper sed -n '/  "Labels": {/, /  },/p' $PODMAN_TUI_LOG
@@ -155,7 +155,7 @@ load helpers_tui
     podman_tui_select_pod_cmd "remove"
     podman_tui_send_inputs "Enter"
     podman_tui_send_inputs "Enter"
-    sleep 1
+    sleep 2
 
     run_podman pod ls --format "{{ .Name }}" --filter "name=$TEST_POD_NAME"
     assert "$output" "=~" "" "expected $TEST_POD_NAME pod removal"
@@ -163,7 +163,7 @@ load helpers_tui
 
 @test "pod prune" {
     podman pod create --name $TEST_POD_NAME --label $TEST_LABEL || echo done
-    sleep 1
+    sleep 2
     
     # switch to pods view
     # select prune command from pod commands dialog

--- a/test/005-container.bats
+++ b/test/005-container.bats
@@ -68,7 +68,7 @@ load helpers_tui
 
     # go to "Create" button and press Enter
     podman_tui_send_inputs "Tab" "Tab" "Tab" "Enter"
-    sleep 1
+    sleep 2
 
     # get created container information
     container_information=$(podman container ls --all --pod --filter "name=podman_tui_test_container01" --format \
@@ -103,7 +103,7 @@ load helpers_tui
     podman_tui_set_view "containers"
     podman_tui_select_item $container_index
     podman_tui_select_container_cmd "start"
-    sleep 1
+    sleep 2
 
     run_podman container ls --all --filter="name=$TEST_CONTAINER_NAME" --format "'{{ .Status }}'"
     assert "$output" =~ "Up" "expected $TEST_CONTAINER_NAME to be up"
@@ -132,7 +132,7 @@ load helpers_tui
     sleep 1
     podman_tui_send_inputs "echo Space test Space > Space a.txt" "Enter"
     podman_tui_send_inputs "Tab" "Enter"
-    sleep 1
+    sleep 2
 
     run_podman container exec $TEST_CONTAINER_NAME cat a.txt
 
@@ -148,7 +148,7 @@ load helpers_tui
     podman_tui_set_view "containers"
     podman_tui_select_item $container_index
     podman_tui_select_container_cmd "inspect"
-    sleep 1
+    sleep 2
 
     run_helper sed -n '/  "Labels": {/, /  },/p' $PODMAN_TUI_LOG
 
@@ -179,7 +179,7 @@ load helpers_tui
     podman_tui_set_view "containers"
     podman_tui_select_item $container_index
     podman_tui_select_container_cmd "top"
-    sleep 1
+    sleep 2
 
     run_helper grep -w "USER PID PPID" $PODMAN_TUI_LOG
     assert "$output" "=~" 'USER PID PPID' "expected 'USER PID PPID' in the logs"
@@ -194,7 +194,7 @@ load helpers_tui
     podman_tui_set_view "containers"
     podman_tui_select_item $container_index
     podman_tui_select_container_cmd "port"
-    sleep 1
+    sleep 2
 
     container_ports=$(podman container ls --all --filter="name=$TEST_CONTAINER_NAME" --format "{{ .Ports }}")
     run_helper grep -w "$container_ports" $PODMAN_TUI_LOG
@@ -210,7 +210,7 @@ load helpers_tui
     podman_tui_set_view "containers"
     podman_tui_select_item $container_index
     podman_tui_select_container_cmd "pause"
-    sleep 1
+    sleep 2
 
     run_podman container ls --all --filter="name=$TEST_CONTAINER_NAME" --format "'{{ .Status }}'"
     assert "$output" =~ "paused" "expected $TEST_CONTAINER_NAME to be paused"
@@ -225,7 +225,7 @@ load helpers_tui
     podman_tui_set_view "containers"
     podman_tui_select_item $container_index
     podman_tui_select_container_cmd "unpause"
-    sleep 1
+    sleep 2
 
     run_podman container ls --all --filter="name=$TEST_CONTAINER_NAME" --format "'{{ .Status }}'"
     assert "$output" =~ "Up" "expected $TEST_CONTAINER_NAME to be Up"
@@ -240,7 +240,7 @@ load helpers_tui
     podman_tui_set_view "containers"
     podman_tui_select_item $container_index
     podman_tui_select_container_cmd "stop"
-    sleep 1
+    sleep 2
 
     run_podman container ls --all --filter="name=$TEST_CONTAINER_NAME" --format "'{{ .Status }}'"
     assert "$output" =~ "Exited" "expected $TEST_CONTAINER_NAME to be Up"
@@ -256,7 +256,7 @@ load helpers_tui
     podman_tui_set_view "containers"
     podman_tui_select_item $container_index
     podman_tui_select_container_cmd "kill"
-    sleep 1
+    sleep 2
 
     run_podman container ls --all --filter="name=$TEST_CONTAINER_NAME" --format "'{{ .Status }}'"
     assert "$output" =~ "Exited" "expected $TEST_CONTAINER_NAME to be killed"
@@ -272,7 +272,7 @@ load helpers_tui
     podman_tui_select_item $container_index
     podman_tui_select_container_cmd "remove"
     podman_tui_send_inputs "Enter"
-    sleep 1
+    sleep 2
 
     run_podman container ls --all --format "'{{ .Names }}'"
     assert "$output" !~ "$TEST_CONTAINER_NAME" "expected $TEST_CONTAINER_NAME to be removed"
@@ -291,7 +291,7 @@ load helpers_tui
     podman_tui_select_container_cmd "rename"
     podman_tui_send_inputs ${TEST_CONTAINER_NAME}_renamed
     podman_tui_send_inputs "Tab" "Tab" "Enter"
-    sleep 1
+    sleep 2
     
     run_podman container ls --all --filter "name=${TEST_CONTAINER_NAME}\$" --format "'{{ json .Names }}'"
     assert "$output" "!~" "${TEST_CONTAINER_NAME}" "expected ${TEST_CONTAINER_NAME} to be not in the list"

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -15,12 +15,12 @@ function setup() {
     systemctl ${user_service_management} start podman.socket
 
     # create tmux session
-    tmux_sessions=$(tmux list-sessions | grep "$TMUX_SESSION:" || echo -e "\c")
+    tmux_sessions=$(tmux list-sessions | grep "$TMUX_SESSION:" 2> /dev/null || echo -e "\c")
     if [ "${tmux_sessions}" != "" ] ; then 
         tmux kill-session -t $TMUX_SESSION
     fi
     /bin/rm -rf ${PODMAN_TUI_LOG}
-    run_helper tmux new-session -s $TMUX_SESSION -d ${PODMAN_TUI_DEBUG}
+    run_helper tmux new-session -s $TMUX_SESSION -d "${PODMAN_TUI_DEBUG}"
     # wait to load the interface
     sleep 5
 }

--- a/test/helpers_tui.bash
+++ b/test/helpers_tui.bash
@@ -145,12 +145,13 @@ function podman_tui_select_pod_cmd() {
     menu_index=6;;
   "start")
     menu_index=7;;
+  # index 8 stats
   "stop")
-    menu_index=8;;
-  "top")
     menu_index=9;;
-  "unpause")
+  "top")
     menu_index=10;;
+  "unpause")
+    menu_index=11;;
   esac
 
   podman_tui_select_menu $menu_index
@@ -187,12 +188,13 @@ function podman_tui_select_container_cmd() {
     menu_index=10;;
   "start")
     menu_index=11;;
+  # index 12 stats
   "stop")
-    menu_index=12;;
-  "top")
     menu_index=13;;
-  "unpause")
+  "top")
     menu_index=14;;
+  "unpause")
+    menu_index=15;;
   esac
 
   podman_tui_select_menu $menu_index


### PR DESCRIPTION
- increase wait time for some of tests so it won't fail on nodes with low resource.

- stats command was added to tui for container and pod views however command index was not updated for those views.

Signed-off-by: Navid Yaghoobi <n.yaghoobi.s@gmail.com>