### PR TITLE
podman-tui-image Containerfile

### DIFF
--- a/contrib/podman-tui-image/Containerfile
+++ b/contrib/podman-tui-image/Containerfile
@@ -1,0 +1,28 @@
+# upstream/Containerfile
+#
+# Build podman-tui container image from the latest
+# upstream version of podman-tui Github.
+# https://github.com/containers/podman-tui
+#
+FROM registry.fedoraproject.org/fedora:latest
+ENV GOPATH=/root/podman-tui
+
+# Install software dependencies to build podman-tui
+RUN yum -y update; yum -y install --enablerepo=updates-testing \
+    make pkgconfig go git \
+    btrfs-progs-devel device-mapper-devel gpgme-devel libassuan-devel; \
+    mkdir /root/podman-tui; \
+    git clone https://github.com/containers/podman-tui.git /root/podman-tui/src/github.com/containers/podman-tui; \
+    cd /root/podman-tui/src/github.com/containers/podman-tui; \
+    make binary; \
+    make install; \
+    cd /root/; \
+    /bin/rm -rf /root/podman-tui/*; \
+    mkdir -p /root/.config/podman-tui/; \
+    touch /root/.config/podman-tui/podman-tui.conf; \
+    yum -y remove git golang make; \
+    yum clean all;
+
+VOLUME /ssh_keys/
+
+ENV TERM=xterm-256color

--- a/contrib/podman-tui-image/README.md
+++ b/contrib/podman-tui-image/README.md
@@ -1,0 +1,21 @@
+# podman-tui-image
+
+## Overview
+
+This directory contains the Containerfile to create the podman-tui-image container
+image.
+
+The container image is built using the latest Fedora and then podman-tui
+is built (upstream) and installed into it.
+
+## Usage
+
+```
+# Build the podman-tui image
+podman build -t podman-tui -f Containerfile
+
+# Run the image and attach using the host's network
+# Bind mount ssh keys volume for SSH connection to remote podman nodes
+# Set SSH identity passphrase if required
+podman run -it --name podman-tui-app -e CONTAINER_PASSPHRASE="<ssh key passphrase>" -v <ssh_keys_dir>:/ssh_keys/:Z --net=host podman-tui podman-tui
+```


### PR DESCRIPTION
Adding Containerfile for building podman-tui container image.
The image is built using latest Fedora and then podman-tui is built and installed.

Signed-off-by: Navid Yaghoobi <n.yaghoobi.s@gmail.com>