### PR TITLE
networks screen refresh after network prune command

### DIFF
--- a/ui/networks/commands.go
+++ b/ui/networks/commands.go
@@ -76,12 +76,13 @@ func (nets *Networks) prune() {
 	nets.progressDialog.SetTitle("network purne in progress")
 	nets.progressDialog.Display()
 	prune := func() {
-		err := networks.Prune()
-		nets.progressDialog.Hide()
-		if err != nil {
+		if err := networks.Prune(); err != nil {
+			nets.progressDialog.Hide()
 			nets.displayError("NETWORK PRUNE ERROR", err)
 			return
 		}
+		nets.UpdateData()
+		nets.progressDialog.Hide()
 	}
 	go prune()
 }


### PR DESCRIPTION
Network prune command is not generting system events, therefore the tui will not refresh the screen after prune command.
Refreshing networks screen after network prune.

Signed-off-by: Navid Yaghoobi <n.yaghoobi.s@gmail.com>