### PR TITLE
error dialog ui update to separate the title from the error message

### DIFF
--- a/ui/containers/commands.go
+++ b/ui/containers/commands.go
@@ -48,15 +48,9 @@ func (cnt *Containers) runCommand(cmd string) {
 }
 
 func (cnt *Containers) displayError(title string, err error) {
-	var message string
-	if title != "" {
-		message = fmt.Sprintf("%s: %v", title, err)
-	} else {
-		message = fmt.Sprintf("%v", err)
-	}
-
 	log.Error().Msgf("%s: %v", strings.ToLower(title), err)
-	cnt.errorDialog.SetText(message)
+	cnt.errorDialog.SetTitle(title)
+	cnt.errorDialog.SetText(fmt.Sprintf("%v", err))
 	cnt.errorDialog.Display()
 }
 

--- a/ui/dialogs/error.go
+++ b/ui/dialogs/error.go
@@ -1,6 +1,8 @@
 package dialogs
 
 import (
+	"fmt"
+
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 	"github.com/rs/zerolog/log"
@@ -10,6 +12,8 @@ import (
 type ErrorDialog struct {
 	*tview.Box
 	modal   *tview.Modal
+	title   string
+	message string
 	display bool
 }
 
@@ -17,7 +21,7 @@ type ErrorDialog struct {
 func NewErrorDialog() *ErrorDialog {
 	dialog := ErrorDialog{
 		Box:     tview.NewBox(),
-		modal:   tview.NewModal().SetBackgroundColor(tcell.ColorRed).AddButtons([]string{"OK"}),
+		modal:   tview.NewModal().SetBackgroundColor(tcell.ColorOrangeRed).AddButtons([]string{"OK"}),
 		display: false,
 	}
 	dialog.modal.SetDoneFunc(func(buttonIndex int, buttonLabel string) {
@@ -40,12 +44,19 @@ func (d *ErrorDialog) IsDisplay() bool {
 // Hide stops displaying this primitive
 func (d *ErrorDialog) Hide() {
 	d.SetText("")
+	d.title = ""
+	d.message = ""
 	d.display = false
 }
 
 // SetText sets error dialog message
 func (d *ErrorDialog) SetText(message string) {
-	d.modal.SetText(message)
+	d.message = message
+}
+
+// SetTitle sets error dialog message title
+func (d *ErrorDialog) SetTitle(title string) {
+	d.title = title
 }
 
 // HasFocus returns whether or not this primitive has focus
@@ -71,7 +82,6 @@ func (d *ErrorDialog) InputHandler() func(event *tcell.EventKey, setFocus func(p
 
 // SetRect set rects for this primitive.
 func (d *ErrorDialog) SetRect(x, y, width, height int) {
-
 	d.Box.SetRect(x, y, width, height)
 }
 
@@ -83,6 +93,12 @@ func (d *ErrorDialog) GetRect() (int, int, int, int) {
 
 // Draw draws this primitive onto the screen.
 func (d *ErrorDialog) Draw(screen tcell.Screen) {
+	var errorMessage string
+	if d.title != "" {
+		errorMessage = fmt.Sprintf("[darkred::b]%s[-::-]\n", d.title)
+	}
+	errorMessage = errorMessage + d.message
+	d.modal.SetText(errorMessage)
 	d.modal.Draw(screen)
 }
 

--- a/ui/images/commands.go
+++ b/ui/images/commands.go
@@ -32,15 +32,9 @@ func (img *Images) runCommand(cmd string) {
 }
 
 func (img *Images) displayError(title string, err error) {
-	var message string
-	if title != "" {
-		message = fmt.Sprintf("%s: %v", title, err)
-	} else {
-		message = fmt.Sprintf("%v", err)
-	}
-
 	log.Error().Msgf("%s: %v", strings.ToLower(title), err)
-	img.errorDialog.SetText(message)
+	img.errorDialog.SetTitle(title)
+	img.errorDialog.SetText(fmt.Sprintf("%v", err))
 	img.errorDialog.Display()
 }
 

--- a/ui/networks/commands.go
+++ b/ui/networks/commands.go
@@ -22,15 +22,9 @@ func (nets *Networks) runCommand(cmd string) {
 }
 
 func (nets *Networks) displayError(title string, err error) {
-	var message string
-	if title != "" {
-		message = fmt.Sprintf("%s: %v", title, err)
-	} else {
-		message = fmt.Sprintf("%v", err)
-	}
-
 	log.Error().Msgf("%s: %v", strings.ToLower(title), err)
-	nets.errorDialog.SetText(message)
+	nets.errorDialog.SetTitle(title)
+	nets.errorDialog.SetText(fmt.Sprintf("%v", err))
 	nets.errorDialog.Display()
 }
 

--- a/ui/pods/commands.go
+++ b/ui/pods/commands.go
@@ -41,15 +41,9 @@ func (p *Pods) runCommand(cmd string) {
 }
 
 func (p *Pods) displayError(title string, err error) {
-	var message string
-	if title != "" {
-		message = fmt.Sprintf("%s: %v", title, err)
-	} else {
-		message = fmt.Sprintf("%v", err)
-	}
-
 	log.Error().Msgf("%s: %v", strings.ToLower(title), err)
-	p.errorDialog.SetText(message)
+	p.errorDialog.SetTitle(title)
+	p.errorDialog.SetText(fmt.Sprintf("%v", err))
 	p.errorDialog.Display()
 }
 

--- a/ui/system/system.go
+++ b/ui/system/system.go
@@ -142,10 +142,6 @@ func NewSystem() *System {
 		sys.eventDialog.SetText("")
 		sys.UpdateConnectionsData()
 	})
-	// set error dialog functions
-	sys.errorDialog.SetDoneFunc(func() {
-		sys.errorDialog.Hide()
-	})
 	// set connection create dialog functions
 	sys.connAddDialog.SetCancelFunc(sys.connAddDialog.Hide)
 	sys.connAddDialog.SetAddFunc(func() {

--- a/ui/volumes/commands.go
+++ b/ui/volumes/commands.go
@@ -22,15 +22,9 @@ func (vols *Volumes) runCommand(cmd string) {
 }
 
 func (vols *Volumes) displayError(title string, err error) {
-	var message string
-	if title != "" {
-		message = fmt.Sprintf("%s: %v", title, err)
-	} else {
-		message = fmt.Sprintf("%v", err)
-	}
-
 	log.Error().Msgf("%s: %v", strings.ToLower(title), err)
-	vols.errorDialog.SetText(message)
+	vols.errorDialog.SetTitle(title)
+	vols.errorDialog.SetText(fmt.Sprintf("%v", err))
 	vols.errorDialog.Display()
 }
 


### PR DESCRIPTION
Error dialog was displaying both error title and message on the same line.
![error_dialog_old](https://user-images.githubusercontent.com/5696685/161420978-cc6765bc-cd0a-472d-9b3f-3c59f110af34.png)

The error dialog primitive has been updated to separate the error title from the message with different text style.

![error_dialog_new](https://user-images.githubusercontent.com/5696685/161420980-4080560b-da22-468e-84d3-3205e976ba5f.png)


Signed-off-by: Navid Yaghoobi <n.yaghoobi.s@gmail.com>