### PR TITLE
activating left/right key to switch between different pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,26 +59,28 @@ Flags:
 
 podman-tui uses following keyboard keys for different actions:
 
-| Action                           | Command   |
-| -------------------------------- | --------- |
-| Display command menu             | m         |
-| Switch to next screen            | l         |
-| Switch to previous screen        | h         |
-| Move up                          | k         |
-| Move down                        | j         |
-| Exit application                 | Ctrl+c    |
-| Close the active dialog          | Esc       |
-| Switch between interface widgets | Tab       |
-| Move up/down                     | Up/Down   |
-| Scroll Up                        | Page Up   |
-| Scroll Down                      | Page Down |
-| Display help screen              | F1        |
-| Display system screen            | F2        |
-| Display pods screen              | F3        |
-| Display containers screen        | F4        |
-| Display volumes screen           | F5        |
-| Display images screen            | F6        |
-| Display networks screen          | F7        |
+| Action                           | Key        |
+| -------------------------------- | ---------- |
+| Display command menu             | m          |
+| Switch to next screen            | l          |
+| Switch to previous screen        | h          |
+| Move up                          | k          |
+| Move down                        | j          |
+| Exit application                 | Ctrl+c     |
+| Close the active dialog          | Esc        |
+| Switch between interface widgets | Tab        |
+| Delete selected item             | Delete     |
+| Move up/down                     | Up/Down    |
+| Previous/Next screen             | Left/Right |
+| Scroll Up                        | Page Up    |
+| Scroll Down                      | Page Down  |
+| Display help screen              | F1         |
+| Display system screen            | F2         |
+| Display pods screen              | F3         |
+| Display containers screen        | F4         |
+| Display volumes screen           | F5         |
+| Display images screen            | F6         |
+| Display networks screen          | F7         |
 
 ---
 

--- a/app/app.go
+++ b/app/app.go
@@ -135,6 +135,8 @@ func (app *App) Run() error {
 			os.Exit(0)
 		}
 		if !app.frontScreenHasActiveDialog() {
+			event = utils.ParseKeyEventKey(event)
+
 			// previous and next screen keys
 			switch event.Rune() {
 			case utils.NextScreenKey.Rune():

--- a/ui/utils/keys.go
+++ b/ui/utils/keys.go
@@ -52,15 +52,25 @@ var (
 		KeyLabel: "Delete",
 		KeyDesc:  "delete the selected item",
 	}
-	ArrorUpKey = uiKeyInfo{
+	ArrowUpKey = uiKeyInfo{
 		Key:      tcell.KeyUp,
 		KeyLabel: "Arrow Up",
 		KeyDesc:  "move up",
 	}
-	ArrorDownKey = uiKeyInfo{
+	ArrowDownKey = uiKeyInfo{
 		Key:      tcell.KeyDown,
 		KeyLabel: "Arrow Down",
 		KeyDesc:  "move down",
+	}
+	ArrowLeftKey = uiKeyInfo{
+		Key:      tcell.KeyLeft,
+		KeyLabel: "Arrow Left",
+		KeyDesc:  "previous screen",
+	}
+	ArrowRightKey = uiKeyInfo{
+		Key:      tcell.KeyRight,
+		KeyLabel: "Arrow Right",
+		KeyDesc:  "next screen",
 	}
 	ScrollUpKey = uiKeyInfo{
 		Key:      tcell.KeyPgUp,
@@ -125,8 +135,10 @@ var (
 		CloseDialogKey,
 		SwitchFocusKey,
 		DeleteKey,
-		ArrorUpKey,
-		ArrorDownKey,
+		ArrowUpKey,
+		ArrowDownKey,
+		ArrowLeftKey,
+		ArrowRightKey,
 		ScrollUpKey,
 		ScrollDownKey,
 		AppExitKey,
@@ -172,6 +184,13 @@ func ParseKeyEventKey(event *tcell.EventKey) *tcell.EventKey {
 		return tcell.NewEventKey(MoveUpKey.Key, MoveUpKey.KeyRune, tcell.ModNone)
 	case MoveDownKey.KeyRune:
 		return tcell.NewEventKey(MoveDownKey.Key, MoveDownKey.KeyRune, tcell.ModNone)
+	}
+
+	switch event.Key() {
+	case ArrowLeftKey.Key:
+		return tcell.NewEventKey(PreviousScreenKey.Key, PreviousScreenKey.KeyRune, tcell.ModNone)
+	case ArrowRightKey.Key:
+		return tcell.NewEventKey(NextScreenKey.Key, NextScreenKey.KeyRune, tcell.ModNone)
 	}
 
 	return event


### PR DESCRIPTION
Activating \<Arrow Left\> and \<Arrow Right\> keys to switch between different pages (connections, pods, containers, images, networks and volumes). 

- Left: switch to previous screen
- Right: switch to next screen

Signed-off-by: Navid Yaghoobi <n.yaghoobi.s@gmail.com>