### PR TITLE
removing image index from name field string search result

### DIFF
--- a/ui/images/imgdialogs/search.go
+++ b/ui/images/imgdialogs/search.go
@@ -2,6 +2,7 @@ package imgdialogs
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/containers/podman-tui/ui/dialogs"
 	"github.com/containers/podman-tui/ui/utils"
@@ -372,6 +373,10 @@ func (d *ImageSearchDialog) UpdateResults(data [][]string) {
 		automated := data[i][5]
 		if automated == "[OK]" {
 			automated = "\u2705"
+		}
+
+		if strings.Index(name, index+"/") == 0 {
+			name = strings.Replace(name, index+"/", "", 1)
 		}
 
 		// index column


### PR DESCRIPTION
In the image search result, the name field value starts with the same value as the image index field, this duplicated infromation does not look good in image search dialog and its not required as well.
Removing image index value from it's name before displaying in the search dialog

![image_search_after](https://user-images.githubusercontent.com/5696685/163660153-4f73b89e-2354-4a4a-8042-f11d512b88b5.png)

Previous look:

![image_search_before](https://user-images.githubusercontent.com/5696685/163660336-3a21f50f-415b-4b4e-86e9-19f468f7299f.png)


Signed-off-by: Navid Yaghoobi <n.yaghoobi.s@gmail.com>