### PR TITLE
adding capability to run under windows os

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ SELINUXOPT ?= $(shell test -x /usr/sbin/selinuxenabled && selinuxenabled && echo
 default: all
 
 .PHONY: all
-all: binary
+all: binary binary-win
 
 .PHONY: binary
 binary: $(TARGET)  ## Build podman-tui binary
@@ -20,6 +20,12 @@ $(TARGET): $(SRC)
 	@mkdir -p $(BIN)
 	@echo "running go build"
 	@go build -o $(BIN)/$(TARGET)
+
+.PHONY: binary-win
+binary-win:  ## Build podman-tui.exe windows binary
+	@mkdir -p $(BIN)/windows/
+	@echo "running go build for windows"
+	@env GOOS=windows  GOARCH=amd64 go build -o $(BIN)/windows/$(TARGET).exe -tags "containers_image_openpgp windows remote"
 
 .PHONY: clean
 clean:

--- a/config/utils.go
+++ b/config/utils.go
@@ -11,9 +11,9 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/containers/podman-tui/ui/utils"
 	"github.com/containers/podman/v4/libpod/define"
 	"github.com/containers/podman/v4/pkg/terminal"
-	"github.com/containers/storage/pkg/unshare"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
@@ -23,7 +23,7 @@ func configPath() (string, error) {
 	if configHome := os.Getenv("XDG_CONFIG_HOME"); configHome != "" {
 		return filepath.Join(configHome, _configPath), nil
 	}
-	home, err := unshare.HomeDir()
+	home, err := utils.UserHomeDir()
 	if err != nil {
 		return "", err
 	}

--- a/ui/containers/cntdialogs/create.go
+++ b/ui/containers/cntdialogs/create.go
@@ -127,9 +127,10 @@ func NewContainerCreateDialog() *ContainerCreateDialog {
 		containerImageVolumeField:    tview.NewDropDown(),
 	}
 
-	bgColor := utils.Styles.ImageHistoryDialog.BgColor
+	bgColor := utils.Styles.ContainerCreateDialog.BgColor
 	ddUnselectedStyle := utils.Styles.DropdownStyle.Unselected
 	ddselectedStyle := utils.Styles.DropdownStyle.Selected
+	inputFieldBgColor := utils.Styles.InputFieldPrimitive.BgColor
 
 	containerDialog.categories.SetDynamicColors(true).
 		SetWrap(true).
@@ -144,29 +145,38 @@ func NewContainerCreateDialog() *ContainerCreateDialog {
 	containerDialog.containerNameField.SetLabelWidth(basicInfoPageLabelWidth)
 	containerDialog.containerNameField.SetBackgroundColor(bgColor)
 	containerDialog.containerNameField.SetLabelColor(tcell.ColorWhite)
+	containerDialog.containerNameField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// image field
 	containerDialog.containerImageField.SetLabel("select image:")
 	containerDialog.containerImageField.SetLabelWidth(basicInfoPageLabelWidth)
 	containerDialog.containerImageField.SetBackgroundColor(bgColor)
 	containerDialog.containerImageField.SetLabelColor(tcell.ColorWhite)
 	containerDialog.containerImageField.SetListStyles(ddUnselectedStyle, ddselectedStyle)
+	containerDialog.containerImageField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// pod field
 	containerDialog.containerPodField.SetLabel("select pod:")
 	containerDialog.containerPodField.SetLabelWidth(basicInfoPageLabelWidth)
 	containerDialog.containerPodField.SetBackgroundColor(bgColor)
 	containerDialog.containerPodField.SetLabelColor(tcell.ColorWhite)
 	containerDialog.containerPodField.SetListStyles(ddUnselectedStyle, ddselectedStyle)
+	containerDialog.containerPodField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// labels field
 	containerDialog.containerLabelsField.SetLabel("labels:")
 	containerDialog.containerLabelsField.SetLabelWidth(basicInfoPageLabelWidth)
 	containerDialog.containerLabelsField.SetBackgroundColor(bgColor)
 	containerDialog.containerLabelsField.SetLabelColor(tcell.ColorWhite)
+	containerDialog.containerLabelsField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// remove field
 	containerDialog.containerRemoveField.SetLabel("remove container after exit ")
 	//containerDialog.containerRemoveField.SetLabelWidth(basicInfoPageLabelWidth)
 	containerDialog.containerRemoveField.SetBackgroundColor(bgColor)
 	containerDialog.containerRemoveField.SetLabelColor(tcell.ColorWhite)
 	containerDialog.containerRemoveField.SetChecked(true)
+	containerDialog.containerRemoveField.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// networking setup page
 	networkingPageLabelWidth := 13
@@ -175,22 +185,29 @@ func NewContainerCreateDialog() *ContainerCreateDialog {
 	containerDialog.containerHostnameField.SetLabelWidth(networkingPageLabelWidth)
 	containerDialog.containerHostnameField.SetBackgroundColor(bgColor)
 	containerDialog.containerHostnameField.SetLabelColor(tcell.ColorWhite)
+	containerDialog.containerHostnameField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// IP field
 	containerDialog.containerIPAddrField.SetLabel("IP address:")
 	containerDialog.containerIPAddrField.SetLabelWidth(networkingPageLabelWidth)
 	containerDialog.containerIPAddrField.SetBackgroundColor(bgColor)
 	containerDialog.containerIPAddrField.SetLabelColor(tcell.ColorWhite)
+	containerDialog.containerIPAddrField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// mac field
 	containerDialog.containerMacAddrField.SetLabel("MAC address:")
 	containerDialog.containerMacAddrField.SetLabelWidth(networkingPageLabelWidth)
 	containerDialog.containerMacAddrField.SetBackgroundColor(bgColor)
 	containerDialog.containerMacAddrField.SetLabelColor(tcell.ColorWhite)
+	containerDialog.containerMacAddrField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// network field
 	containerDialog.containerNetworkField.SetLabel("network:")
 	containerDialog.containerNetworkField.SetLabelWidth(networkingPageLabelWidth)
 	containerDialog.containerNetworkField.SetBackgroundColor(bgColor)
 	containerDialog.containerNetworkField.SetLabelColor(tcell.ColorWhite)
 	containerDialog.containerNetworkField.SetListStyles(ddUnselectedStyle, ddselectedStyle)
+	containerDialog.containerNetworkField.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// ports setup page
 	portPageLabelWidth := 15
@@ -199,17 +216,22 @@ func NewContainerCreateDialog() *ContainerCreateDialog {
 	containerDialog.containerPortPublishField.SetLabelWidth(portPageLabelWidth)
 	containerDialog.containerPortPublishField.SetBackgroundColor(bgColor)
 	containerDialog.containerPortPublishField.SetLabelColor(tcell.ColorWhite)
+	containerDialog.containerPortPublishField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// expose field
 	containerDialog.containerPortExposeField.SetLabel("expose ports:")
 	containerDialog.containerPortExposeField.SetLabelWidth(portPageLabelWidth)
 	containerDialog.containerPortExposeField.SetBackgroundColor(bgColor)
 	containerDialog.containerPortExposeField.SetLabelColor(tcell.ColorWhite)
+	containerDialog.containerPortExposeField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// publish all field
 	containerDialog.ContainerPortPublishAllField.SetLabel("publish all ")
 	containerDialog.ContainerPortPublishAllField.SetLabelWidth(portPageLabelWidth)
 	containerDialog.ContainerPortPublishAllField.SetBackgroundColor(bgColor)
 	containerDialog.ContainerPortPublishAllField.SetLabelColor(tcell.ColorWhite)
 	containerDialog.ContainerPortPublishAllField.SetChecked(false)
+	containerDialog.ContainerPortPublishAllField.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// dns setup page
 	dnsPageLabelWidth := 13
@@ -218,16 +240,21 @@ func NewContainerCreateDialog() *ContainerCreateDialog {
 	containerDialog.containerDNSServersField.SetLabelWidth(dnsPageLabelWidth)
 	containerDialog.containerDNSServersField.SetBackgroundColor(bgColor)
 	containerDialog.containerDNSServersField.SetLabelColor(tcell.ColorWhite)
+	containerDialog.containerDNSServersField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// IP field
 	containerDialog.containerDNSOptionsField.SetLabel("DNS options:")
 	containerDialog.containerDNSOptionsField.SetLabelWidth(dnsPageLabelWidth)
 	containerDialog.containerDNSOptionsField.SetBackgroundColor(bgColor)
 	containerDialog.containerDNSOptionsField.SetLabelColor(tcell.ColorWhite)
+	containerDialog.containerDNSOptionsField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// mac field
 	containerDialog.containerDNSSearchField.SetLabel("DNS search:")
 	containerDialog.containerDNSSearchField.SetLabelWidth(dnsPageLabelWidth)
 	containerDialog.containerDNSSearchField.SetBackgroundColor(bgColor)
 	containerDialog.containerDNSSearchField.SetLabelColor(tcell.ColorWhite)
+	containerDialog.containerDNSSearchField.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// volume setup page
 	volumePageLabelWidth := 14
@@ -237,6 +264,7 @@ func NewContainerCreateDialog() *ContainerCreateDialog {
 	containerDialog.containerVolumeField.SetBackgroundColor(bgColor)
 	containerDialog.containerVolumeField.SetLabelColor(tcell.ColorWhite)
 	containerDialog.containerVolumeField.SetListStyles(ddUnselectedStyle, ddselectedStyle)
+	containerDialog.containerVolumeField.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// image volume
 	containerDialog.containerImageVolumeField.SetLabel("Image volume:")
@@ -244,6 +272,7 @@ func NewContainerCreateDialog() *ContainerCreateDialog {
 	containerDialog.containerImageVolumeField.SetBackgroundColor(bgColor)
 	containerDialog.containerImageVolumeField.SetLabelColor(tcell.ColorWhite)
 	containerDialog.containerImageVolumeField.SetListStyles(ddUnselectedStyle, ddselectedStyle)
+	containerDialog.containerImageVolumeField.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// category pages
 	containerDialog.categoryPages.SetBackgroundColor(bgColor)
@@ -254,6 +283,7 @@ func NewContainerCreateDialog() *ContainerCreateDialog {
 	containerDialog.form.AddButton("Cancel", nil)
 	containerDialog.form.AddButton("Create", nil)
 	containerDialog.form.SetButtonsAlign(tview.AlignRight)
+	containerDialog.form.SetButtonBackgroundColor(utils.Styles.ButtonPrimitive.BgColor)
 
 	containerDialog.layout.AddItem(tview.NewBox().SetBackgroundColor(bgColor), 1, 0, true)
 	containerDialog.setupLayout()
@@ -269,7 +299,7 @@ func NewContainerCreateDialog() *ContainerCreateDialog {
 }
 
 func (d *ContainerCreateDialog) setupLayout() {
-	bgColor := utils.Styles.ImageHistoryDialog.BgColor
+	bgColor := utils.Styles.ContainerCreateDialog.BgColor
 
 	// basic info page
 	d.basicInfoPage.SetDirection(tview.FlexRow)
@@ -598,13 +628,18 @@ func (d *ContainerCreateDialog) SetCreateFunc(handler func()) *ContainerCreateDi
 }
 
 func (d *ContainerCreateDialog) setActiveCategory(index int) {
+	fgColor := utils.Styles.ContainerCreateDialog.FgColor
+	bgColor := int(utils.Styles.ButtonPrimitive.BgColor)
+	ctgTextColor := utils.GetColorName(fgColor)
+	ctgBgColor := utils.GetColorName(tcell.Color(bgColor))
+
 	d.activePageIndex = index
 	d.categories.Clear()
 	var ctgList []string
 	alignedList, _ := utils.AlignStringListWidth(d.categoryLabels)
 	for i := 0; i < len(alignedList); i++ {
 		if i == index {
-			ctgList = append(ctgList, fmt.Sprintf("[white:blue:b]-> %s ", alignedList[i]))
+			ctgList = append(ctgList, fmt.Sprintf("[%s:%s:b]-> %s ", ctgTextColor, ctgBgColor, alignedList[i]))
 			continue
 		}
 		ctgList = append(ctgList, fmt.Sprintf("[-:-:-]   %s ", alignedList[i]))

--- a/ui/containers/cntdialogs/exec.go
+++ b/ui/containers/cntdialogs/exec.go
@@ -76,6 +76,7 @@ func NewContainerExecDialog() *ContainerExecDialog {
 	}
 	bgColor := utils.Styles.ContainerExecDialog.BgColor
 	fgColor := utils.Styles.ContainerExecDialog.FgColor
+	inputFieldBgColor := utils.Styles.InputFieldPrimitive.BgColor
 
 	// label (container ID and Name)
 	dialog.label.SetDynamicColors(true)
@@ -89,6 +90,7 @@ func NewContainerExecDialog() *ContainerExecDialog {
 	dialog.command.SetLabel("command:")
 	dialog.command.SetLabelColor(fgColor)
 	dialog.command.SetLabelWidth(execDialogLabelWidth)
+	dialog.command.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// interactive
 	dialog.interactive.SetBackgroundColor(bgColor)
@@ -96,6 +98,7 @@ func NewContainerExecDialog() *ContainerExecDialog {
 	dialog.interactive.SetLabel("interactive:")
 	dialog.interactive.SetLabelColor(fgColor)
 	dialog.interactive.SetLabelWidth(execDialogLabelWidth)
+	dialog.interactive.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// tty
 	tLabel := "tty:"
@@ -104,6 +107,7 @@ func NewContainerExecDialog() *ContainerExecDialog {
 	dialog.tty.SetLabel(tLabel)
 	dialog.tty.SetLabelColor(fgColor)
 	dialog.tty.SetLabelWidth(len(tLabel) + 1)
+	dialog.tty.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// privileged
 	pLabel := "privileged:"
@@ -112,6 +116,7 @@ func NewContainerExecDialog() *ContainerExecDialog {
 	dialog.privileged.SetLabel(pLabel)
 	dialog.privileged.SetLabelColor(fgColor)
 	dialog.privileged.SetLabelWidth(len(pLabel) + 1)
+	dialog.privileged.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// detach
 	dLabel := "detach:"
@@ -120,6 +125,7 @@ func NewContainerExecDialog() *ContainerExecDialog {
 	dialog.detach.SetLabel(dLabel)
 	dialog.detach.SetLabelColor(fgColor)
 	dialog.detach.SetLabelWidth(len(dLabel) + 1)
+	dialog.detach.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// working dir
 	dialog.workingDir.SetBackgroundColor(bgColor)
@@ -127,6 +133,7 @@ func NewContainerExecDialog() *ContainerExecDialog {
 	dialog.workingDir.SetLabel("working dir:")
 	dialog.workingDir.SetLabelColor(fgColor)
 	dialog.workingDir.SetLabelWidth(execDialogLabelWidth)
+	dialog.workingDir.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// env variables
 	dialog.envVariables.SetBackgroundColor(bgColor)
@@ -134,6 +141,7 @@ func NewContainerExecDialog() *ContainerExecDialog {
 	dialog.envVariables.SetLabel("env vars:")
 	dialog.envVariables.SetLabelColor(fgColor)
 	dialog.envVariables.SetLabelWidth(execDialogLabelWidth)
+	dialog.envVariables.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// env file
 	dialog.envFile.SetBackgroundColor(bgColor)
@@ -141,6 +149,7 @@ func NewContainerExecDialog() *ContainerExecDialog {
 	dialog.envFile.SetLabel("env file:")
 	dialog.envFile.SetLabelColor(fgColor)
 	dialog.envFile.SetLabelWidth(execDialogLabelWidth)
+	dialog.envFile.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// detach key
 	dialog.detachKeys.SetBackgroundColor(bgColor)
@@ -148,20 +157,22 @@ func NewContainerExecDialog() *ContainerExecDialog {
 	dialog.detachKeys.SetLabel("detach keys:")
 	dialog.detachKeys.SetLabelColor(fgColor)
 	dialog.detachKeys.SetLabelWidth(execDialogLabelWidth)
+	dialog.detachKeys.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// user
 	dialog.user.SetBackgroundColor(bgColor)
 	dialog.user.SetBorder(false)
 	dialog.user.SetLabel("user: ")
 	dialog.user.SetLabelColor(fgColor)
+	dialog.user.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// form fields
 	dialog.form = tview.NewForm().
 		AddButton("Cancel", nil).
 		AddButton("Execute", nil).
 		SetButtonsAlign(tview.AlignRight)
-
 	dialog.form.SetBackgroundColor(bgColor)
+	dialog.form.SetButtonBackgroundColor(utils.Styles.ButtonPrimitive.BgColor)
 
 	// main dialog layout
 	dialog.layout = tview.NewFlex().SetDirection(tview.FlexRow)

--- a/ui/containers/cntdialogs/stats.go
+++ b/ui/containers/cntdialogs/stats.go
@@ -57,6 +57,7 @@ func NewContainerStatsDialog() *ContainerStatsDialog {
 		AddButton("Cancel", nil).
 		SetButtonsAlign(tview.AlignRight)
 	statsDialog.form.SetBackgroundColor(bgColor)
+	statsDialog.form.SetButtonBackgroundColor(utils.Styles.ButtonPrimitive.BgColor)
 
 	// table layout
 	statLayout := tview.NewFlex().SetDirection(tview.FlexColumn)

--- a/ui/containers/cntdialogs/terminal.go
+++ b/ui/containers/cntdialogs/terminal.go
@@ -87,8 +87,8 @@ func NewContainerExecTerminalDialog() *ContainerExecTerminalDialog {
 	dialog.form = tview.NewForm().
 		AddButton("Close", nil).
 		SetButtonsAlign(tview.AlignRight)
-
 	dialog.form.SetBackgroundColor(bgColor)
+	dialog.form.SetButtonBackgroundColor(utils.Styles.ButtonPrimitive.BgColor)
 
 	//label and terminal layout
 	middleLayout := tview.NewFlex().SetDirection(tview.FlexRow)
@@ -420,13 +420,17 @@ func (d *ContainerExecTerminalDialog) startVTreader() {
 }
 
 func (d *ContainerExecTerminalDialog) setExecInfo(id string, name string, sessionID string) {
+	fgColor := utils.Styles.ContainerExecTerminalDialog.FgColor
+	bgColor := utils.Styles.ContainerExecTerminalDialog.HeaderBgColor
+	headerFgColor := utils.GetColorName(fgColor)
+	headerBgColor := utils.GetColorName(bgColor)
 	d.containerID = id
 	d.sessionID = sessionID
 	if len(sessionID) > utils.IDLength {
 		sessionID = sessionID[0:utils.IDLength]
 	}
 
-	label := fmt.Sprintf("[white:navy:] CONTAINER ID: [white:-:] %s ", id)
+	label := fmt.Sprintf("[%s:%s:] CONTAINER ID: [%s:-:] %s ", headerFgColor, headerBgColor, headerFgColor, id)
 	if name != "" {
 		label = fmt.Sprintf("%s(%s) ", label, name)
 	}

--- a/ui/dialogs/command.go
+++ b/ui/dialogs/command.go
@@ -30,37 +30,40 @@ type CommandDialog struct {
 // NewCommandDialog returns a command list primitive.
 func NewCommandDialog(options [][]string) *CommandDialog {
 
+	headerBgColor := utils.Styles.CommandDialog.HeaderRow.BgColor
+	headerFgColor := utils.Styles.CommandDialog.HeaderRow.FgColor
+	buttonBgColor := utils.Styles.ButtonPrimitive.BgColor
+	bgColor := utils.Styles.CommandDialog.BgColor
+	fgColor := utils.Styles.CommandDialog.FgColor
+
 	form := tview.NewForm().
 		AddButton("Cancel", nil).
 		AddButton("Enter", nil).
 		SetButtonsAlign(tview.AlignRight)
 
-	form.SetBackgroundColor(utils.Styles.CommandDialog.BgColor)
+	form.SetBackgroundColor(bgColor)
+	form.SetButtonBackgroundColor(buttonBgColor)
 
-	bgColor := utils.Styles.CommandDialog.HeaderRow.BgColor
-	fgColor := utils.Styles.CommandDialog.HeaderRow.FgColor
 	cmdsTable := tview.NewTable()
 
 	cmdWidth := 0
 	// command table header
 	cmdsTable.SetCell(0, 0,
-		tview.NewTableCell(fmt.Sprintf("[%s::b]COMMAND", utils.GetColorName(fgColor))).
+		tview.NewTableCell(fmt.Sprintf("[%s::b]COMMAND", utils.GetColorName(headerFgColor))).
 			SetExpansion(1).
-			SetBackgroundColor(bgColor).
-			SetTextColor(fgColor).
+			SetBackgroundColor(headerBgColor).
+			SetTextColor(headerFgColor).
 			SetAlign(tview.AlignLeft).
 			SetSelectable(false))
 	cmdsTable.SetCell(0, 1,
-		tview.NewTableCell(fmt.Sprintf("[%s::b]DESCRIPTION", utils.GetColorName(fgColor))).
+		tview.NewTableCell(fmt.Sprintf("[%s::b]DESCRIPTION", utils.GetColorName(headerFgColor))).
 			SetExpansion(1).
-			SetBackgroundColor(bgColor).
-			SetTextColor(fgColor).
+			SetBackgroundColor(headerBgColor).
+			SetTextColor(headerFgColor).
 			SetAlign(tview.AlignCenter).
 			SetSelectable(false))
 
 	// command table items
-	bgColor = utils.Styles.CommandDialog.BgColor
-	fgColor = utils.Styles.CommandDialog.FgColor
 	col1Width := 0
 	col2Width := 0
 	for i := 0; i < len(options); i++ {

--- a/ui/dialogs/confirm.go
+++ b/ui/dialogs/confirm.go
@@ -48,9 +48,11 @@ func NewConfirmDialog() *ConfirmDialog {
 		AddButton("Enter", nil).
 		SetButtonsAlign(tview.AlignRight)
 	dialog.form.SetBackgroundColor(bgColor)
+	dialog.form.SetButtonBackgroundColor(utils.Styles.ButtonPrimitive.BgColor)
 
 	dialog.layout = tview.NewFlex().SetDirection(tview.FlexRow)
 	dialog.layout.SetBorder(true)
+	dialog.layout.SetBorderColor(fgColor)
 	dialog.layout.SetBackgroundColor(bgColor)
 
 	return dialog
@@ -146,26 +148,25 @@ func (d *ConfirmDialog) setRect() {
 	}
 
 	d.layout.Clear()
-
-	bgColor := utils.Styles.ConfirmDialog.BgColor
 	d.layout.AddItem(d.textview, layoutHeight, 0, true)
 	d.layout.AddItem(d.form, DialogFormHeight, 0, true)
-	d.layout.SetBorder(true)
-	d.layout.SetBackgroundColor(bgColor)
 
 	d.Box.SetRect(d.x, d.y, d.width, d.height)
 }
 
 // Draw draws this primitive onto the screen.
 func (d *ConfirmDialog) Draw(screen tcell.Screen) {
-
+	fgColor := utils.Styles.ConfirmDialog.FgColor
+	bgColor := utils.Styles.ConfirmDialog.BgColor
 	if !d.display {
 		return
 	}
 	d.Box.DrawForSubclass(screen, d)
 	x, y, width, height := d.Box.GetInnerRect()
 	d.layout.SetRect(x, y, width, height)
-	d.layout.SetBorderColor(tcell.ColorBlack)
+	d.layout.SetBorder(true)
+	d.layout.SetBackgroundColor(bgColor)
+	d.layout.SetBorderColor(fgColor)
 	d.layout.Draw(screen)
 }
 

--- a/ui/dialogs/error.go
+++ b/ui/dialogs/error.go
@@ -3,6 +3,7 @@ package dialogs
 import (
 	"fmt"
 
+	"github.com/containers/podman-tui/ui/utils"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 	"github.com/rs/zerolog/log"
@@ -19,11 +20,14 @@ type ErrorDialog struct {
 
 // NewErrorDialog returns new error dialog primitive
 func NewErrorDialog() *ErrorDialog {
+	bgColor := utils.Styles.ErrorDialog.BgColor
 	dialog := ErrorDialog{
 		Box:     tview.NewBox(),
-		modal:   tview.NewModal().SetBackgroundColor(tcell.ColorOrangeRed).AddButtons([]string{"OK"}),
+		modal:   tview.NewModal().SetBackgroundColor(bgColor).AddButtons([]string{"OK"}),
 		display: false,
 	}
+	dialog.modal.SetButtonBackgroundColor(utils.Styles.ButtonPrimitive.BgColor)
+
 	dialog.modal.SetDoneFunc(func(buttonIndex int, buttonLabel string) {
 		dialog.Hide()
 	})
@@ -93,9 +97,11 @@ func (d *ErrorDialog) GetRect() (int, int, int, int) {
 
 // Draw draws this primitive onto the screen.
 func (d *ErrorDialog) Draw(screen tcell.Screen) {
+	hFgColor := utils.Styles.ErrorDialog.HeaderFgColor
+	headerColor := utils.GetColorName(hFgColor)
 	var errorMessage string
 	if d.title != "" {
-		errorMessage = fmt.Sprintf("[darkred::b]%s[-::-]\n", d.title)
+		errorMessage = fmt.Sprintf("[%s::b]%s[-::-]\n", headerColor, d.title)
 	}
 	errorMessage = errorMessage + d.message
 	d.modal.SetText(errorMessage)

--- a/ui/dialogs/input.go
+++ b/ui/dialogs/input.go
@@ -43,7 +43,8 @@ func NewSimpleInputDialog(text string) *SimpleInputDialog {
 		focusElement: siInputElement,
 	}
 
-	bgColor := utils.Styles.CommandDialog.BgColor
+	bgColor := utils.Styles.InputDialog.BgColor
+	fgColor := utils.Styles.InputDialog.FgColor
 
 	dialog.textview = tview.NewTextView().
 		SetDynamicColors(true).
@@ -57,6 +58,7 @@ func NewSimpleInputDialog(text string) *SimpleInputDialog {
 		AddButton("Enter", nil).
 		SetButtonsAlign(tview.AlignRight)
 	dialog.form.SetBackgroundColor(bgColor)
+	dialog.form.SetButtonBackgroundColor(utils.Styles.ButtonPrimitive.BgColor)
 
 	dialog.layout = tview.NewFlex().SetDirection(tview.FlexRow)
 	dialog.layout.SetBorder(true)
@@ -64,8 +66,10 @@ func NewSimpleInputDialog(text string) *SimpleInputDialog {
 
 	dialog.input = tview.NewInputField()
 	dialog.SetInputText(text)
-	dialog.input.SetLabelColor(tcell.ColorWhite)
+	dialog.input.SetLabelColor(fgColor)
 	dialog.input.SetBackgroundColor(bgColor)
+	dialog.input.SetFieldBackgroundColor(utils.Styles.InputFieldPrimitive.BgColor)
+
 	return dialog
 }
 
@@ -99,7 +103,7 @@ func (d *SimpleInputDialog) setLayout(haveDesc bool) {
 	d.layout.AddItem(d.textview, descHeight, 0, true)
 	d.layout.AddItem(d.input, 1, 0, true)
 	d.layout.AddItem(d.form, DialogFormHeight, 0, true)
-	bgColor := utils.Styles.CommandDialog.BgColor
+	bgColor := utils.Styles.InputDialog.BgColor
 	d.layout.SetBorder(true)
 	d.layout.SetBackgroundColor(bgColor)
 }

--- a/ui/dialogs/message.go
+++ b/ui/dialogs/message.go
@@ -34,20 +34,31 @@ func NewMessageDialog(text string) *MessageDialog {
 		SetWrap(true).
 		SetTextAlign(tview.AlignLeft)
 
-	bgColor := utils.Styles.CommandDialog.BgColor
-	dialog.textview.SetTextColor(tcell.ColorBlack)
-	dialog.textview.SetBackgroundColor(bgColor)
-	dialog.textview.SetBorderColor(utils.Styles.CommandDialog.HeaderRow.BgColor)
+	bgColor := utils.Styles.MessageDialog.BgColor
+	terminalBgColor := utils.Styles.MessageDialog.Terminal.BgColor
+	terminalFgColor := utils.Styles.MessageDialog.Terminal.FgColor
+	buttonBgColor := utils.Styles.ButtonPrimitive.BgColor
+
+	dialog.textview.SetTextColor(terminalFgColor)
+	dialog.textview.SetBackgroundColor(terminalBgColor)
+	dialog.textview.SetBorderColor(terminalFgColor)
 	dialog.textview.SetBorder(true)
+
+	// textview layout
+	tlayout := tview.NewFlex().SetDirection(tview.FlexColumn)
+	tlayout.AddItem(utils.EmptyBoxSpace(bgColor), 1, 0, false)
+	tlayout.AddItem(dialog.textview, 0, 1, true)
+	tlayout.AddItem(utils.EmptyBoxSpace(bgColor), 1, 0, false)
 
 	dialog.form = tview.NewForm().
 		AddButton("Enter", nil).
 		SetButtonsAlign(tview.AlignRight)
 
 	dialog.form.SetBackgroundColor(bgColor)
+	dialog.form.SetButtonBackgroundColor(buttonBgColor)
 
 	dialog.layout = tview.NewFlex().SetDirection(tview.FlexRow)
-	dialog.layout.AddItem(dialog.textview, 0, 1, true)
+	dialog.layout.AddItem(tlayout, 0, 1, true)
 	dialog.layout.AddItem(dialog.form, DialogFormHeight, 0, true)
 	dialog.layout.SetBorder(true)
 	dialog.layout.SetBackgroundColor(bgColor)

--- a/ui/dialogs/progress.go
+++ b/ui/dialogs/progress.go
@@ -3,6 +3,7 @@ package dialogs
 import (
 	"fmt"
 
+	"github.com/containers/podman-tui/ui/utils"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 	"github.com/rs/zerolog/log"
@@ -103,6 +104,7 @@ func (d *ProgressDialog) InputHandler() func(event *tcell.EventKey, setFocus fun
 }
 
 func (d *ProgressDialog) tickStr(max int) string {
+	barColor := utils.GetColorName(utils.Styles.ProgressDailog.PgBarColor)
 	counter := d.counterValue
 	if counter < max-4 {
 		d.counterValue++
@@ -122,5 +124,6 @@ func (d *ProgressDialog) tickStr(max int) string {
 		prgEndStr = prgEndStr + fmt.Sprintf("[black::]%s", prgCell)
 	}
 
-	return fmt.Sprintf("%s[orange::]%s%s", prgHeadStr, prgStr, prgEndStr)
+	progress := fmt.Sprintf("%s[%s::]%s%s", prgHeadStr, barColor, prgStr, prgEndStr)
+	return progress
 }

--- a/ui/dialogs/top.go
+++ b/ui/dialogs/top.go
@@ -38,6 +38,7 @@ func NewTopDialog() *TopDialog {
 		AddButton("Enter", nil).
 		SetButtonsAlign(tview.AlignRight)
 	dialog.form.SetBackgroundColor(bgColor)
+	dialog.form.SetButtonBackgroundColor(utils.Styles.ButtonPrimitive.BgColor)
 
 	// table layout
 	tableLayout := tview.NewFlex().SetDirection(tview.FlexColumn)

--- a/ui/images/commands.go
+++ b/ui/images/commands.go
@@ -154,7 +154,7 @@ func (img *Images) inspect() {
 func (img *Images) cprune() {
 	img.confirmDialog.SetTitle("podman image prune")
 	img.confirmData = "prune"
-	img.confirmDialog.SetText("Are you sure you want to remove all unused images")
+	img.confirmDialog.SetText("Are you sure you want to remove all unused images ?")
 	img.confirmDialog.Display()
 }
 

--- a/ui/images/imgdialogs/build.go
+++ b/ui/images/imgdialogs/build.go
@@ -155,6 +155,7 @@ func NewImageBuildDialog() *ImageBuildDialog {
 	}
 	bgColor := utils.Styles.ImageBuildDialog.BgColor
 	fgColor := utils.Styles.ImageBuildDialog.FgColor
+	inputFieldBgColor := utils.Styles.InputFieldPrimitive.BgColor
 	ddUnselectedStyle := utils.Styles.DropdownStyle.Unselected
 	ddselectedStyle := utils.Styles.DropdownStyle.Selected
 
@@ -172,11 +173,15 @@ func NewImageBuildDialog() *ImageBuildDialog {
 	buildDialog.contextDirectoryPath.SetLabelWidth(basicInfoPageLabelWidth)
 	buildDialog.contextDirectoryPath.SetBackgroundColor(bgColor)
 	buildDialog.contextDirectoryPath.SetLabelColor(fgColor)
+	buildDialog.contextDirectoryPath.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// Containerfile path field
 	buildDialog.containerFilePath.SetLabel("Containerfiles:")
 	buildDialog.containerFilePath.SetLabelWidth(basicInfoPageLabelWidth)
 	buildDialog.containerFilePath.SetBackgroundColor(bgColor)
 	buildDialog.containerFilePath.SetLabelColor(fgColor)
+	buildDialog.containerFilePath.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// pull policy dropdown
 	buildDialog.pullPolicyField.SetLabel("Pull policy:")
 	buildDialog.pullPolicyField.SetLabelWidth(basicInfoPageLabelWidth)
@@ -189,17 +194,21 @@ func NewImageBuildDialog() *ImageBuildDialog {
 		define.PullNever.String()},
 		nil)
 	buildDialog.pullPolicyField.SetListStyles(ddUnselectedStyle, ddselectedStyle)
+	buildDialog.pullPolicyField.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// tag field
 	buildDialog.tagField.SetLabel("Image tag:")
 	buildDialog.tagField.SetLabelWidth(basicInfoPageLabelWidth)
 	buildDialog.tagField.SetBackgroundColor(bgColor)
 	buildDialog.tagField.SetLabelColor(fgColor)
+	buildDialog.tagField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// registry field
 	buildDialog.registryField.SetLabel("Registry:")
 	buildDialog.registryField.SetLabelWidth(basicInfoPageLabelWidth)
 	buildDialog.registryField.SetBackgroundColor(bgColor)
 	buildDialog.registryField.SetLabelColor(fgColor)
+	buildDialog.registryField.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// layers setup page
 	layersFirstColWidth := 14
@@ -207,6 +216,8 @@ func NewImageBuildDialog() *ImageBuildDialog {
 	buildDialog.buildArgsField.SetLabelWidth(layersFirstColWidth)
 	buildDialog.buildArgsField.SetBackgroundColor(bgColor)
 	buildDialog.buildArgsField.SetLabelColor(fgColor)
+	buildDialog.buildArgsField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// layers
 	layersLabel := "Layers:"
 	buildDialog.layersField.SetBackgroundColor(bgColor)
@@ -214,6 +225,8 @@ func NewImageBuildDialog() *ImageBuildDialog {
 	buildDialog.layersField.SetLabel(layersLabel)
 	buildDialog.layersField.SetLabelColor(fgColor)
 	buildDialog.layersField.SetLabelWidth(len(layersLabel) + 1)
+	buildDialog.layersField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// no-cache
 	noCacheLabel := "No cache:"
 	buildDialog.noCacheField.SetBackgroundColor(bgColor)
@@ -221,32 +234,40 @@ func NewImageBuildDialog() *ImageBuildDialog {
 	buildDialog.noCacheField.SetLabel(noCacheLabel)
 	buildDialog.noCacheField.SetLabelColor(fgColor)
 	buildDialog.noCacheField.SetLabelWidth(len(noCacheLabel) + 1)
+	buildDialog.noCacheField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// squash
 	buildDialog.SquashField.SetBackgroundColor(bgColor)
 	buildDialog.SquashField.SetBorder(false)
 	buildDialog.SquashField.SetLabel("Squash:")
 	buildDialog.SquashField.SetLabelColor(fgColor)
 	buildDialog.SquashField.SetLabelWidth(layersFirstColWidth)
+	buildDialog.SquashField.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// labels
 	buildDialog.labelsField.SetLabel("Labels:")
 	buildDialog.labelsField.SetLabelWidth(layersFirstColWidth)
 	buildDialog.labelsField.SetBackgroundColor(bgColor)
 	buildDialog.labelsField.SetLabelColor(fgColor)
+	buildDialog.labelsField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// annotations
 	buildDialog.annotationsField.SetLabel("Annotations:")
 	buildDialog.annotationsField.SetLabelWidth(layersFirstColWidth)
 	buildDialog.annotationsField.SetBackgroundColor(bgColor)
 	buildDialog.annotationsField.SetLabelColor(fgColor)
+	buildDialog.annotationsField.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// force remove field
 	buildDialog.removeCntField.SetLabel("Remove containers: ")
 	buildDialog.removeCntField.SetBackgroundColor(bgColor)
 	buildDialog.removeCntField.SetLabelColor(fgColor)
+	buildDialog.removeCntField.SetFieldBackgroundColor(inputFieldBgColor)
 
 	buildDialog.forceRemoveCntField.SetLabel("Force remove: ")
 	buildDialog.forceRemoveCntField.SetBackgroundColor(bgColor)
 	buildDialog.forceRemoveCntField.SetLabelColor(fgColor)
+	buildDialog.forceRemoveCntField.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// networking setup page
 	networkingPageLabelWidth := 13
@@ -261,32 +282,43 @@ func NewImageBuildDialog() *ImageBuildDialog {
 		define.NetworkEnabled.String()},
 		nil)
 	buildDialog.networkField.SetListStyles(ddUnselectedStyle, ddselectedStyle)
+	buildDialog.networkField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// http proxy checkbox
 	buildDialog.httpProxyField.SetBackgroundColor(bgColor)
 	buildDialog.httpProxyField.SetBorder(false)
 	buildDialog.httpProxyField.SetLabel("HTTP proxy:")
 	buildDialog.httpProxyField.SetLabelColor(fgColor)
 	buildDialog.httpProxyField.SetLabelWidth(networkingPageLabelWidth)
+	buildDialog.httpProxyField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// Add host field
 	buildDialog.addHostField.SetLabel("Add Host:")
 	buildDialog.addHostField.SetLabelWidth(networkingPageLabelWidth)
 	buildDialog.addHostField.SetBackgroundColor(bgColor)
 	buildDialog.addHostField.SetLabelColor(tcell.ColorWhite)
+	buildDialog.addHostField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// DNS servers field
 	buildDialog.dnsServersField.SetLabel("DNS servers:")
 	buildDialog.dnsServersField.SetLabelWidth(networkingPageLabelWidth)
 	buildDialog.dnsServersField.SetBackgroundColor(bgColor)
 	buildDialog.dnsServersField.SetLabelColor(tcell.ColorWhite)
+	buildDialog.dnsServersField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// DNS options field
 	buildDialog.dnsOptionsField.SetLabel("DNS options:")
 	buildDialog.dnsOptionsField.SetLabelWidth(networkingPageLabelWidth)
 	buildDialog.dnsOptionsField.SetBackgroundColor(bgColor)
 	buildDialog.dnsOptionsField.SetLabelColor(tcell.ColorWhite)
+	buildDialog.dnsOptionsField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// DNS search field
 	buildDialog.dnsSearchField.SetLabel("DNS search:")
 	buildDialog.dnsSearchField.SetLabelWidth(networkingPageLabelWidth)
 	buildDialog.dnsSearchField.SetBackgroundColor(bgColor)
 	buildDialog.dnsSearchField.SetLabelColor(tcell.ColorWhite)
+	buildDialog.dnsSearchField.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// capability page
 	capabilityPageLabelWidth := 12
@@ -295,11 +327,14 @@ func NewImageBuildDialog() *ImageBuildDialog {
 	buildDialog.addCapabilityField.SetLabelWidth(capabilityPageLabelWidth)
 	buildDialog.addCapabilityField.SetBackgroundColor(bgColor)
 	buildDialog.addCapabilityField.SetLabelColor(tcell.ColorWhite)
+	buildDialog.addCapabilityField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// remove capability field
 	buildDialog.removeCapabilityField.SetLabel("Remove cap:")
 	buildDialog.removeCapabilityField.SetLabelWidth(capabilityPageLabelWidth)
 	buildDialog.removeCapabilityField.SetBackgroundColor(bgColor)
 	buildDialog.removeCapabilityField.SetLabelColor(tcell.ColorWhite)
+	buildDialog.removeCapabilityField.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// cpu and memory page
 	cpuMemoryLabelWidth := 14
@@ -310,40 +345,53 @@ func NewImageBuildDialog() *ImageBuildDialog {
 	buildDialog.cpuPeriodField.SetFieldWidth(cpuMemoryFieldWidth)
 	buildDialog.cpuPeriodField.SetBackgroundColor(bgColor)
 	buildDialog.cpuPeriodField.SetLabelColor(tcell.ColorWhite)
+	buildDialog.cpuPeriodField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// cpu quota field
 	buildDialog.cpuQuataField.SetLabel("CPU quota:")
 	buildDialog.cpuQuataField.SetLabelWidth(cpuMemoryLabelWidth)
 	buildDialog.cpuQuataField.SetFieldWidth(cpuMemoryFieldWidth)
 	buildDialog.cpuQuataField.SetBackgroundColor(bgColor)
 	buildDialog.cpuQuataField.SetLabelColor(tcell.ColorWhite)
+	buildDialog.cpuQuataField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// cpu shares field
 	buildDialog.cpuSharesField.SetLabel("CPU shares:")
 	buildDialog.cpuSharesField.SetLabelWidth(cpuMemoryLabelWidth)
 	buildDialog.cpuSharesField.SetFieldWidth(cpuMemoryFieldWidth)
 	buildDialog.cpuSharesField.SetBackgroundColor(bgColor)
 	buildDialog.cpuSharesField.SetLabelColor(tcell.ColorWhite)
+	buildDialog.cpuSharesField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// cpuset cpus field
 	buildDialog.cpuSetCpusField.SetLabel("CPU set cpus:")
 	buildDialog.cpuSetCpusField.SetLabelWidth(cpuMemoryLabelWidth)
 	buildDialog.cpuSetCpusField.SetFieldWidth(cpuMemoryFieldWidth)
 	buildDialog.cpuSetCpusField.SetBackgroundColor(bgColor)
 	buildDialog.cpuSetCpusField.SetLabelColor(tcell.ColorWhite)
+	buildDialog.cpuSetCpusField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// cpuset mems field
 	buildDialog.cpuSetMemsField.SetLabel(" CPU set mems:")
 	buildDialog.cpuSetMemsField.SetLabelWidth(cpuMemoryLabelWidth + 1)
 	buildDialog.cpuSetMemsField.SetBackgroundColor(bgColor)
 	buildDialog.cpuSetMemsField.SetLabelColor(tcell.ColorWhite)
+	buildDialog.cpuSetMemsField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// memory field
 	buildDialog.memoryField.SetLabel("memory:")
 	buildDialog.memoryField.SetLabelWidth(cpuMemoryLabelWidth)
 	buildDialog.memoryField.SetFieldWidth(cpuMemoryFieldWidth)
 	buildDialog.memoryField.SetBackgroundColor(bgColor)
 	buildDialog.memoryField.SetLabelColor(tcell.ColorWhite)
+	buildDialog.memoryField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// memory swap field
 	buildDialog.memorySwapField.SetLabel(" memory swap:")
 	buildDialog.memorySwapField.SetLabelWidth(cpuMemoryLabelWidth + 1)
 	buildDialog.memorySwapField.SetBackgroundColor(bgColor)
 	buildDialog.memorySwapField.SetLabelColor(tcell.ColorWhite)
+	buildDialog.memorySwapField.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// category pages
 	buildDialog.categoryPages.SetBackgroundColor(bgColor)
@@ -354,6 +402,7 @@ func NewImageBuildDialog() *ImageBuildDialog {
 	buildDialog.form.AddButton("Cancel", nil)
 	buildDialog.form.AddButton("Build", nil)
 	buildDialog.form.SetButtonsAlign(tview.AlignRight)
+	buildDialog.form.SetButtonBackgroundColor(utils.Styles.ButtonPrimitive.BgColor)
 
 	// layout
 	buildDialog.setupLayout()
@@ -782,13 +831,18 @@ func (d *ImageBuildDialog) initData() {
 }
 
 func (d *ImageBuildDialog) setActiveCategory(index int) {
+	bgColor := utils.Styles.ButtonPrimitive.BgColor
+	fgColor := utils.Styles.ImageBuildDialog.FgColor
+
+	ctgFgColor := utils.GetColorName(fgColor)
+	ctgBgColor := utils.GetColorName(bgColor)
 	d.activePageIndex = index
 	d.categories.Clear()
 	var ctgList []string
 	alignedList, _ := utils.AlignStringListWidth(d.categoryLabels)
 	for i := 0; i < len(alignedList); i++ {
 		if i == index {
-			ctgList = append(ctgList, fmt.Sprintf("[white:blue:b]-> %s ", alignedList[i]))
+			ctgList = append(ctgList, fmt.Sprintf("[%s:%s:b]-> %s ", ctgFgColor, ctgBgColor, alignedList[i]))
 			continue
 		}
 		ctgList = append(ctgList, fmt.Sprintf("[-:-:-]   %s ", alignedList[i]))

--- a/ui/images/imgdialogs/history.go
+++ b/ui/images/imgdialogs/history.go
@@ -47,6 +47,7 @@ func NewImageHistoryDialog() *ImageHistoryDialog {
 		AddButton("Enter", nil).
 		SetButtonsAlign(tview.AlignRight)
 	dialog.form.SetBackgroundColor(bgColor)
+	dialog.form.SetButtonBackgroundColor(utils.Styles.ButtonPrimitive.BgColor)
 
 	// table layout
 	tableLayout := tview.NewFlex().SetDirection(tview.FlexColumn)

--- a/ui/images/imgdialogs/import.go
+++ b/ui/images/imgdialogs/import.go
@@ -55,6 +55,7 @@ func NewImageImportDialog() *ImageImportDialog {
 
 	bgColor := utils.Styles.ImageImportDialog.BgColor
 	fgColor := utils.Styles.ImageImportDialog.FgColor
+	inputFieldBgColor := utils.Styles.InputFieldPrimitive.BgColor
 	labelWidth := 11
 
 	// path field
@@ -62,30 +63,35 @@ func NewImageImportDialog() *ImageImportDialog {
 	dialog.path.SetLabelColor(fgColor)
 	dialog.path.SetLabel("Source:")
 	dialog.path.SetLabelWidth(labelWidth)
+	dialog.path.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// change field
 	dialog.change.SetBackgroundColor(bgColor)
 	dialog.change.SetLabelColor(fgColor)
 	dialog.change.SetLabel("Change:")
 	dialog.change.SetLabelWidth(labelWidth)
+	dialog.change.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// commit field
 	dialog.commitMessage.SetBackgroundColor(bgColor)
 	dialog.commitMessage.SetLabelColor(fgColor)
 	dialog.commitMessage.SetLabel("Message:")
 	dialog.commitMessage.SetLabelWidth(labelWidth)
+	dialog.commitMessage.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// reference field
 	dialog.reference.SetBackgroundColor(bgColor)
 	dialog.reference.SetLabelColor(fgColor)
 	dialog.reference.SetLabel("Reference:")
 	dialog.reference.SetLabelWidth(labelWidth)
+	dialog.reference.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// form
 	dialog.form.AddButton("Cancel", nil)
 	dialog.form.AddButton("Import", nil)
 	dialog.form.SetButtonsAlign(tview.AlignRight)
 	dialog.form.SetBackgroundColor(bgColor)
+	dialog.form.SetButtonBackgroundColor(utils.Styles.ButtonPrimitive.BgColor)
 
 	// layout
 	optionsLayout := tview.NewFlex().SetDirection(tview.FlexRow)

--- a/ui/images/imgdialogs/save.go
+++ b/ui/images/imgdialogs/save.go
@@ -57,6 +57,7 @@ func NewImageSaveDialog() *ImageSaveDialog {
 
 	bgColor := utils.Styles.ImageSaveDialog.BgColor
 	fgColor := utils.Styles.ImageSaveDialog.FgColor
+	inputFieldBgColor := utils.Styles.InputFieldPrimitive.BgColor
 	ddUnselectedStyle := utils.Styles.DropdownStyle.Unselected
 	ddselectedStyle := utils.Styles.DropdownStyle.Selected
 	labelWidth := 10
@@ -71,12 +72,14 @@ func NewImageSaveDialog() *ImageSaveDialog {
 	dialog.output.SetLabelColor(fgColor)
 	dialog.output.SetLabel("Output:")
 	dialog.output.SetLabelWidth(labelWidth)
+	dialog.output.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// compress
 	dialog.compress.SetBackgroundColor(bgColor)
 	dialog.compress.SetLabelColor(fgColor)
 	dialog.compress.SetLabel("Compress:")
 	dialog.compress.SetLabelWidth(labelWidth)
+	dialog.compress.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// format
 	dialog.format.SetBackgroundColor(bgColor)
@@ -91,17 +94,20 @@ func NewImageSaveDialog() *ImageSaveDialog {
 		nil)
 	dialog.format.SetListStyles(ddUnselectedStyle, ddselectedStyle)
 	dialog.format.SetCurrentOption(0)
+	dialog.format.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// OciAcceptUncompressed
 	dialog.ociAcceptUncompressed.SetBackgroundColor(bgColor)
 	dialog.ociAcceptUncompressed.SetLabelColor(fgColor)
 	dialog.ociAcceptUncompressed.SetLabel("Accept uncompressed (OCI images): ")
+	dialog.ociAcceptUncompressed.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// form
 	dialog.form.AddButton("Cancel", nil)
 	dialog.form.AddButton("Save", nil)
 	dialog.form.SetButtonsAlign(tview.AlignRight)
 	dialog.form.SetBackgroundColor(bgColor)
+	dialog.form.SetButtonBackgroundColor(utils.Styles.ButtonPrimitive.BgColor)
 
 	// layout
 	compressRow := tview.NewFlex().SetDirection(tview.FlexColumn)

--- a/ui/images/imgdialogs/search.go
+++ b/ui/images/imgdialogs/search.go
@@ -52,10 +52,17 @@ func NewImageSearchDialog() *ImageSearchDialog {
 	}
 	bgColor := utils.Styles.ImageSearchDialog.BgColor
 	fgColor := utils.Styles.ImageSearchDialog.FgColor
+	inputFieldBgColor := utils.Styles.InputFieldPrimitive.BgColor
+	buttonBgColor := utils.Styles.ButtonPrimitive.BgColor
+
+	dialog.searchButton.SetBackgroundColor(buttonBgColor)
+	dialog.searchButton.SetLabelColorActivated(buttonBgColor)
+
 	dialog.input.SetLabel("search term: ")
 	dialog.input.SetLabelColor(fgColor)
 	dialog.input.SetFieldWidth(searchFieldMaxSize)
 	dialog.input.SetBackgroundColor(bgColor)
+	dialog.input.SetFieldBackgroundColor(inputFieldBgColor)
 
 	dialog.searchLayout = tview.NewFlex().SetDirection(tview.FlexColumn)
 	dialog.searchLayout.AddItem(tview.NewBox().SetBackgroundColor(bgColor), 1, 0, true)
@@ -80,6 +87,7 @@ func NewImageSearchDialog() *ImageSearchDialog {
 		AddButton("Pull", nil).
 		SetButtonsAlign(tview.AlignRight)
 	dialog.form.SetBackgroundColor(bgColor)
+	dialog.form.SetButtonBackgroundColor(buttonBgColor)
 
 	dialog.layout = tview.NewFlex().SetDirection(tview.FlexRow)
 	dialog.layout.SetBorder(true)

--- a/ui/networks/netdialogs/create.go
+++ b/ui/networks/netdialogs/create.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	networkCreateDialogMaxWidth = 80
-	networkCreateDialogHeight   = 19
+	networkCreateDialogHeight   = 17
 )
 
 const (
@@ -67,7 +67,7 @@ type NetworkCreateDialog struct {
 
 // NewNetworkCreateDialog returns new network create dialog primitive NetworkCreateDialog
 func NewNetworkCreateDialog() *NetworkCreateDialog {
-	podDialog := NetworkCreateDialog{
+	netDialog := NetworkCreateDialog{
 		Box:                       tview.NewBox(),
 		layout:                    tview.NewFlex().SetDirection(tview.FlexRow),
 		categories:                tview.NewTextView(),
@@ -90,99 +90,118 @@ func NewNetworkCreateDialog() *NetworkCreateDialog {
 		networkDisableDNSCheckBox: tview.NewCheckbox(),
 	}
 
-	bgColor := utils.Styles.ImageHistoryDialog.BgColor
+	bgColor := utils.Styles.NetworkCreateDialog.BgColor
+	fgColor := utils.Styles.NetworkCreateDialog.FgColor
+	inputFieldBgColor := utils.Styles.InputFieldPrimitive.BgColor
+	buttonBgColor := utils.Styles.ButtonPrimitive.BgColor
 
-	podDialog.categories.SetDynamicColors(true).
+	netDialog.categories.SetDynamicColors(true).
 		SetWrap(true).
 		SetTextAlign(tview.AlignLeft)
-	podDialog.categories.SetBackgroundColor(bgColor)
-	podDialog.categories.SetBorder(true)
+	netDialog.categories.SetBackgroundColor(bgColor)
+	netDialog.categories.SetBorder(true)
 
 	// basic information setup page
 	basicInfoPageLabelWidth := 12
 	// name field
-	podDialog.networkNameField.SetLabel("name:")
-	podDialog.networkNameField.SetLabelWidth(basicInfoPageLabelWidth)
-	podDialog.networkNameField.SetBackgroundColor(bgColor)
-	podDialog.networkNameField.SetLabelColor(tcell.ColorWhite)
+	netDialog.networkNameField.SetLabel("name:")
+	netDialog.networkNameField.SetLabelWidth(basicInfoPageLabelWidth)
+	netDialog.networkNameField.SetBackgroundColor(bgColor)
+	netDialog.networkNameField.SetLabelColor(fgColor)
+	netDialog.networkNameField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// labels field
-	podDialog.networkLabelsField.SetLabel("labels:")
-	podDialog.networkLabelsField.SetLabelWidth(basicInfoPageLabelWidth)
-	podDialog.networkLabelsField.SetBackgroundColor(bgColor)
-	podDialog.networkLabelsField.SetLabelColor(tcell.ColorWhite)
+	netDialog.networkLabelsField.SetLabel("labels:")
+	netDialog.networkLabelsField.SetLabelWidth(basicInfoPageLabelWidth)
+	netDialog.networkLabelsField.SetBackgroundColor(bgColor)
+	netDialog.networkLabelsField.SetLabelColor(fgColor)
+	netDialog.networkLabelsField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// internal check box
-	podDialog.networkInternalCheckBox.SetLabel("internal")
-	podDialog.networkInternalCheckBox.SetLabelWidth(basicInfoPageLabelWidth)
-	podDialog.networkInternalCheckBox.SetChecked(false)
-	podDialog.networkInternalCheckBox.SetBackgroundColor(bgColor)
-	podDialog.networkInternalCheckBox.SetLabelColor(tcell.ColorWhite)
+	netDialog.networkInternalCheckBox.SetLabel("internal")
+	netDialog.networkInternalCheckBox.SetLabelWidth(basicInfoPageLabelWidth)
+	netDialog.networkInternalCheckBox.SetChecked(false)
+	netDialog.networkInternalCheckBox.SetBackgroundColor(bgColor)
+	netDialog.networkInternalCheckBox.SetLabelColor(fgColor)
+	netDialog.networkInternalCheckBox.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// drivers
-	podDialog.networkDriverField.SetLabel("drivers:")
-	podDialog.networkDriverField.SetLabelWidth(basicInfoPageLabelWidth)
-	podDialog.networkDriverField.SetBackgroundColor(bgColor)
-	podDialog.networkDriverField.SetLabelColor(tcell.ColorWhite)
+	netDialog.networkDriverField.SetLabel("drivers:")
+	netDialog.networkDriverField.SetLabelWidth(basicInfoPageLabelWidth)
+	netDialog.networkDriverField.SetBackgroundColor(bgColor)
+	netDialog.networkDriverField.SetLabelColor(fgColor)
+	netDialog.networkDriverField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// drivers options
-	podDialog.networkDriverOptionsField.SetLabel("options:")
-	podDialog.networkDriverOptionsField.SetLabelWidth(basicInfoPageLabelWidth)
-	podDialog.networkDriverOptionsField.SetBackgroundColor(bgColor)
-	podDialog.networkDriverOptionsField.SetLabelColor(tcell.ColorWhite)
+	netDialog.networkDriverOptionsField.SetLabel("options:")
+	netDialog.networkDriverOptionsField.SetLabelWidth(basicInfoPageLabelWidth)
+	netDialog.networkDriverOptionsField.SetBackgroundColor(bgColor)
+	netDialog.networkDriverOptionsField.SetLabelColor(fgColor)
+	netDialog.networkDriverOptionsField.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// ip settings page
 	ipSettingsPageLabelWidth := 12
 	// ipv6 check box
-	podDialog.networkIpv6CheckBox.SetLabel("IPv6")
-	podDialog.networkIpv6CheckBox.SetLabelWidth(ipSettingsPageLabelWidth)
-	podDialog.networkIpv6CheckBox.SetChecked(false)
-	podDialog.networkIpv6CheckBox.SetBackgroundColor(bgColor)
-	podDialog.networkIpv6CheckBox.SetLabelColor(tcell.ColorWhite)
+	netDialog.networkIpv6CheckBox.SetLabel("IPv6")
+	netDialog.networkIpv6CheckBox.SetLabelWidth(ipSettingsPageLabelWidth)
+	netDialog.networkIpv6CheckBox.SetChecked(false)
+	netDialog.networkIpv6CheckBox.SetBackgroundColor(bgColor)
+	netDialog.networkIpv6CheckBox.SetLabelColor(tcell.ColorWhite)
+	netDialog.networkIpv6CheckBox.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// gateway
-	podDialog.networkGatewayField.SetLabel("gateway:")
-	podDialog.networkGatewayField.SetLabelWidth(basicInfoPageLabelWidth)
-	podDialog.networkGatewayField.SetBackgroundColor(bgColor)
-	podDialog.networkGatewayField.SetLabelColor(tcell.ColorWhite)
+	netDialog.networkGatewayField.SetLabel("gateway:")
+	netDialog.networkGatewayField.SetLabelWidth(basicInfoPageLabelWidth)
+	netDialog.networkGatewayField.SetBackgroundColor(bgColor)
+	netDialog.networkGatewayField.SetLabelColor(tcell.ColorWhite)
+	netDialog.networkGatewayField.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// ip range
-	podDialog.networkIPRangeField.SetLabel("IP range:")
-	podDialog.networkIPRangeField.SetLabelWidth(basicInfoPageLabelWidth)
-	podDialog.networkIPRangeField.SetBackgroundColor(bgColor)
-	podDialog.networkIPRangeField.SetLabelColor(tcell.ColorWhite)
+	netDialog.networkIPRangeField.SetLabel("IP range:")
+	netDialog.networkIPRangeField.SetLabelWidth(basicInfoPageLabelWidth)
+	netDialog.networkIPRangeField.SetBackgroundColor(bgColor)
+	netDialog.networkIPRangeField.SetLabelColor(tcell.ColorWhite)
+	netDialog.networkIPRangeField.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// subnet
-	podDialog.networkSubnetField.SetLabel("subnet:")
-	podDialog.networkSubnetField.SetLabelWidth(basicInfoPageLabelWidth)
-	podDialog.networkSubnetField.SetBackgroundColor(bgColor)
-	podDialog.networkSubnetField.SetLabelColor(tcell.ColorWhite)
+	netDialog.networkSubnetField.SetLabel("subnet:")
+	netDialog.networkSubnetField.SetLabelWidth(basicInfoPageLabelWidth)
+	netDialog.networkSubnetField.SetBackgroundColor(bgColor)
+	netDialog.networkSubnetField.SetLabelColor(tcell.ColorWhite)
+	netDialog.networkSubnetField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// dns check box
-	podDialog.networkDisableDNSCheckBox.SetLabel("disable DNS")
-	podDialog.networkDisableDNSCheckBox.SetLabelWidth(basicInfoPageLabelWidth)
-	podDialog.networkDisableDNSCheckBox.SetChecked(false)
-	podDialog.networkDisableDNSCheckBox.SetBackgroundColor(bgColor)
-	podDialog.networkDisableDNSCheckBox.SetLabelColor(tcell.ColorWhite)
+	netDialog.networkDisableDNSCheckBox.SetLabel("disable DNS")
+	netDialog.networkDisableDNSCheckBox.SetLabelWidth(basicInfoPageLabelWidth)
+	netDialog.networkDisableDNSCheckBox.SetChecked(false)
+	netDialog.networkDisableDNSCheckBox.SetBackgroundColor(bgColor)
+	netDialog.networkDisableDNSCheckBox.SetLabelColor(tcell.ColorWhite)
+	netDialog.networkDisableDNSCheckBox.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// category pages
-	podDialog.categoryPages.SetBackgroundColor(bgColor)
-	podDialog.categoryPages.SetBorder(true)
+	netDialog.categoryPages.SetBackgroundColor(bgColor)
+	netDialog.categoryPages.SetBorder(true)
 
 	// form
-	podDialog.form.SetBackgroundColor(bgColor)
-	podDialog.form.AddButton("Cancel", nil)
-	podDialog.form.AddButton("Create", nil)
-	podDialog.form.SetButtonsAlign(tview.AlignRight)
+	netDialog.form.SetBackgroundColor(bgColor)
+	netDialog.form.AddButton("Cancel", nil)
+	netDialog.form.AddButton("Create", nil)
+	netDialog.form.SetButtonsAlign(tview.AlignRight)
+	netDialog.form.SetButtonBackgroundColor(buttonBgColor)
 
-	podDialog.layout.AddItem(tview.NewBox().SetBackgroundColor(bgColor), 1, 0, true)
-	podDialog.setupLayout()
-	podDialog.layout.SetBackgroundColor(bgColor)
-	podDialog.layout.SetBorder(true)
-	podDialog.layout.SetTitle("PODMAN NETWORK CREATE")
-	podDialog.layout.AddItem(podDialog.form, dialogs.DialogFormHeight, 0, true)
+	netDialog.layout.AddItem(tview.NewBox().SetBackgroundColor(bgColor), 1, 0, true)
+	netDialog.setupLayout()
+	netDialog.layout.SetBackgroundColor(bgColor)
+	netDialog.layout.SetBorder(true)
+	netDialog.layout.SetTitle("PODMAN NETWORK CREATE")
+	netDialog.layout.AddItem(netDialog.form, dialogs.DialogFormHeight, 0, true)
 
-	podDialog.setActiveCategory(0)
-	return &podDialog
+	netDialog.setActiveCategory(0)
+	return &netDialog
 }
 
 func (d *NetworkCreateDialog) setupLayout() {
-	bgColor := utils.Styles.ImageHistoryDialog.BgColor
+	bgColor := utils.Styles.NetworkCreateDialog.BgColor
 
 	// basic info page
 	d.basicInfoPage.SetDirection(tview.FlexRow)
@@ -413,13 +432,18 @@ func (d *NetworkCreateDialog) SetCreateFunc(handler func()) *NetworkCreateDialog
 }
 
 func (d *NetworkCreateDialog) setActiveCategory(index int) {
+	fgColor := utils.Styles.NetworkCreateDialog.FgColor
+	bgColor := utils.Styles.ButtonPrimitive.BgColor
+	ctgTextColor := utils.GetColorName(fgColor)
+	ctgBgColor := utils.GetColorName(bgColor)
+
 	d.activePageIndex = index
 	d.categories.Clear()
 	var ctgList []string
 	alignedList, _ := utils.AlignStringListWidth(d.categoryLabels)
 	for i := 0; i < len(d.categoryLabels); i++ {
 		if i == index {
-			ctgList = append(ctgList, fmt.Sprintf("[white:blue:b]-> %s ", alignedList[i]))
+			ctgList = append(ctgList, fmt.Sprintf("[%s:%s:b]-> %s ", ctgTextColor, ctgBgColor, alignedList[i]))
 			continue
 		}
 		ctgList = append(ctgList, fmt.Sprintf("[-:-:-]   %s ", alignedList[i]))

--- a/ui/pods/poddialogs/create.go
+++ b/ui/pods/poddialogs/create.go
@@ -114,7 +114,9 @@ func NewPodCreateDialog() *PodCreateDialog {
 		//podNetworkAliasesField:   tview.NewInputField(),
 	}
 
-	bgColor := utils.Styles.ImageHistoryDialog.BgColor
+	bgColor := utils.Styles.PodCreateDialog.BgColor
+	fgColor := utils.Styles.PodCreateDialog.FgColor
+	inputFieldBgColor := utils.Styles.InputFieldPrimitive.BgColor
 
 	podDialog.categories.SetDynamicColors(true).
 		SetWrap(true).
@@ -128,18 +130,23 @@ func NewPodCreateDialog() *PodCreateDialog {
 	podDialog.podNameField.SetLabel("name:")
 	podDialog.podNameField.SetLabelWidth(basicInfoPageLabelWidth)
 	podDialog.podNameField.SetBackgroundColor(bgColor)
-	podDialog.podNameField.SetLabelColor(tcell.ColorWhite)
+	podDialog.podNameField.SetLabelColor(fgColor)
+	podDialog.podNameField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// no hosts check box
 	podDialog.podNoHostsCheckBox.SetLabel("no hosts")
 	podDialog.podNoHostsCheckBox.SetLabelWidth(basicInfoPageLabelWidth)
 	podDialog.podNoHostsCheckBox.SetChecked(false)
 	podDialog.podNoHostsCheckBox.SetBackgroundColor(bgColor)
-	podDialog.podNoHostsCheckBox.SetLabelColor(tcell.ColorWhite)
+	podDialog.podNoHostsCheckBox.SetLabelColor(fgColor)
+	podDialog.podNoHostsCheckBox.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// labels field
 	podDialog.podLabelsField.SetLabel("labels:")
 	podDialog.podLabelsField.SetLabelWidth(basicInfoPageLabelWidth)
 	podDialog.podLabelsField.SetBackgroundColor(bgColor)
-	podDialog.podLabelsField.SetLabelColor(tcell.ColorWhite)
+	podDialog.podLabelsField.SetLabelColor(fgColor)
+	podDialog.podLabelsField.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// DNS setup page
 	dnsPageLabelWidth := 16
@@ -147,17 +154,22 @@ func NewPodCreateDialog() *PodCreateDialog {
 	podDialog.podDNSServerField.SetLabel("DNS servers:")
 	podDialog.podDNSServerField.SetLabelWidth(dnsPageLabelWidth)
 	podDialog.podDNSServerField.SetBackgroundColor(bgColor)
-	podDialog.podDNSServerField.SetLabelColor(tcell.ColorWhite)
+	podDialog.podDNSServerField.SetLabelColor(fgColor)
+	podDialog.podDNSServerField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// DNS options field
 	podDialog.podDNSOptionsField.SetLabel("DNS options:")
 	podDialog.podDNSOptionsField.SetLabelWidth(dnsPageLabelWidth)
 	podDialog.podDNSOptionsField.SetBackgroundColor(bgColor)
-	podDialog.podDNSOptionsField.SetLabelColor(tcell.ColorWhite)
+	podDialog.podDNSOptionsField.SetLabelColor(fgColor)
+	podDialog.podDNSOptionsField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// DNS search domains field
 	podDialog.podDNSSearchDomaindField.SetLabel("search domains:")
 	podDialog.podDNSSearchDomaindField.SetLabelWidth(dnsPageLabelWidth)
 	podDialog.podDNSSearchDomaindField.SetBackgroundColor(bgColor)
-	podDialog.podDNSSearchDomaindField.SetLabelColor(tcell.ColorWhite)
+	podDialog.podDNSSearchDomaindField.SetLabelColor(fgColor)
+	podDialog.podDNSSearchDomaindField.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// infra page
 	infraPageLabelWidth := 15
@@ -166,18 +178,23 @@ func NewPodCreateDialog() *PodCreateDialog {
 	podDialog.podInfraCheckBox.SetLabelWidth(infraPageLabelWidth)
 	podDialog.podInfraCheckBox.SetChecked(true)
 	podDialog.podInfraCheckBox.SetBackgroundColor(bgColor)
-	podDialog.podInfraCheckBox.SetLabelColor(tcell.ColorWhite)
+	podDialog.podInfraCheckBox.SetLabelColor(fgColor)
+	podDialog.podInfraCheckBox.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// infra command field
 	podDialog.podInfraCommandField.SetLabel("infra command:")
 	podDialog.podInfraCommandField.SetLabelWidth(infraPageLabelWidth)
 	podDialog.podInfraCommandField.SetBackgroundColor(bgColor)
-	podDialog.podInfraCommandField.SetLabelColor(tcell.ColorWhite)
+	podDialog.podInfraCommandField.SetLabelColor(fgColor)
+	podDialog.podInfraCommandField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// infra image field
 	podDialog.podInfraImageField.SetLabel("infra image:")
 	podDialog.podInfraImageField.SetText(podDialog.defaultInfraImage)
 	podDialog.podInfraImageField.SetLabelWidth(infraPageLabelWidth)
 	podDialog.podInfraImageField.SetBackgroundColor(bgColor)
-	podDialog.podInfraImageField.SetLabelColor(tcell.ColorWhite)
+	podDialog.podInfraImageField.SetLabelColor(fgColor)
+	podDialog.podInfraImageField.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// networking page
 	networkingLabelWidth := 17
@@ -185,30 +202,39 @@ func NewPodCreateDialog() *PodCreateDialog {
 	podDialog.podHostnameField.SetLabel("hostname:")
 	podDialog.podHostnameField.SetLabelWidth(networkingLabelWidth)
 	podDialog.podHostnameField.SetBackgroundColor(bgColor)
-	podDialog.podHostnameField.SetLabelColor(tcell.ColorWhite)
+	podDialog.podHostnameField.SetLabelColor(fgColor)
+	podDialog.podHostnameField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// ip address field
 	podDialog.podIPAddressField.SetLabel("ip address:")
 	podDialog.podIPAddressField.SetLabelWidth(networkingLabelWidth)
 	podDialog.podIPAddressField.SetBackgroundColor(bgColor)
-	podDialog.podIPAddressField.SetLabelColor(tcell.ColorWhite)
+	podDialog.podIPAddressField.SetLabelColor(fgColor)
+	podDialog.podIPAddressField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// mac address field
 	podDialog.podMacAddressField.SetLabel("mac address:")
 	podDialog.podMacAddressField.SetLabelWidth(networkingLabelWidth)
 	podDialog.podMacAddressField.SetBackgroundColor(bgColor)
-	podDialog.podMacAddressField.SetLabelColor(tcell.ColorWhite)
+	podDialog.podMacAddressField.SetLabelColor(fgColor)
+	podDialog.podMacAddressField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// host-to-ip map field
 	podDialog.podHostToIPMapField.SetLabel("host-to-ip:")
 	podDialog.podHostToIPMapField.SetLabelWidth(networkingLabelWidth)
 	podDialog.podHostToIPMapField.SetBackgroundColor(bgColor)
-	podDialog.podHostToIPMapField.SetLabelColor(tcell.ColorWhite)
+	podDialog.podHostToIPMapField.SetLabelColor(fgColor)
+	podDialog.podHostToIPMapField.SetFieldBackgroundColor(inputFieldBgColor)
+
 	// network field
 	podDialog.podNetworkField.SetLabel("network:")
 	podDialog.podNetworkField.SetLabelWidth(networkingLabelWidth)
 	podDialog.podNetworkField.SetBackgroundColor(bgColor)
-	podDialog.podNetworkField.SetLabelColor(tcell.ColorWhite)
+	podDialog.podNetworkField.SetLabelColor(fgColor)
 	ddUnselectedStyle := utils.Styles.DropdownStyle.Unselected
 	ddselectedStyle := utils.Styles.DropdownStyle.Selected
 	podDialog.podNetworkField.SetListStyles(ddUnselectedStyle, ddselectedStyle)
+	podDialog.podNetworkField.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// category pages
 	podDialog.categoryPages.SetBackgroundColor(bgColor)
@@ -219,6 +245,7 @@ func NewPodCreateDialog() *PodCreateDialog {
 	podDialog.form.AddButton("Cancel", nil)
 	podDialog.form.AddButton("Create", nil)
 	podDialog.form.SetButtonsAlign(tview.AlignRight)
+	podDialog.form.SetButtonBackgroundColor(utils.Styles.ButtonPrimitive.BgColor)
 
 	podDialog.layout.AddItem(tview.NewBox().SetBackgroundColor(bgColor), 1, 0, true)
 	podDialog.setupLayout()
@@ -234,7 +261,7 @@ func NewPodCreateDialog() *PodCreateDialog {
 }
 
 func (d *PodCreateDialog) setupLayout() {
-	bgColor := utils.Styles.ImageHistoryDialog.BgColor
+	bgColor := utils.Styles.PodCreateDialog.BgColor
 
 	// basic info page
 	d.basicInfoPage.SetDirection(tview.FlexRow)
@@ -511,13 +538,18 @@ func (d *PodCreateDialog) SetCreateFunc(handler func()) *PodCreateDialog {
 }
 
 func (d *PodCreateDialog) setActiveCategory(index int) {
+	fgColor := utils.Styles.PodCreateDialog.FgColor
+	bgColor := utils.Styles.ButtonPrimitive.BgColor
+	ctgTextColor := utils.GetColorName(fgColor)
+	ctgBgColor := utils.GetColorName(bgColor)
+
 	d.activePageIndex = index
 	d.categories.Clear()
 	var ctgList []string
 	alignedList, _ := utils.AlignStringListWidth(d.categoryLabels)
 	for i := 0; i < len(d.categoryLabels); i++ {
 		if i == index {
-			ctgList = append(ctgList, fmt.Sprintf("[white:blue:b]-> %s ", alignedList[i]))
+			ctgList = append(ctgList, fmt.Sprintf("[%s:%s:b]-> %s ", ctgTextColor, ctgBgColor, alignedList[i]))
 			continue
 		}
 		ctgList = append(ctgList, fmt.Sprintf("[-:-:-]   %s ", alignedList[i]))

--- a/ui/pods/poddialogs/stats.go
+++ b/ui/pods/poddialogs/stats.go
@@ -69,6 +69,8 @@ func NewPodStatsDialog() *PodStatsDialog {
 	}
 	bgColor := utils.Styles.PodStatsDialog.BgColor
 	fgColor := utils.Styles.PodStatsDialog.FgColor
+	inputFieldBgColor := utils.Styles.InputFieldPrimitive.BgColor
+
 	ddUnselectedStyle := utils.Styles.DropdownStyle.Unselected
 	ddselectedStyle := utils.Styles.DropdownStyle.Selected
 	// pod dropdown
@@ -78,6 +80,7 @@ func NewPodStatsDialog() *PodStatsDialog {
 	statsDialog.podDropDown.SetBackgroundColor(bgColor)
 	statsDialog.podDropDown.SetLabelColor(fgColor)
 	statsDialog.podDropDown.SetListStyles(ddUnselectedStyle, ddselectedStyle)
+	statsDialog.podDropDown.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// pod sortby dropdown
 	pddSortByLabel := "Sort By:"
@@ -91,6 +94,7 @@ func NewPodStatsDialog() *PodStatsDialog {
 		"container name",
 		"cpu %",
 		"mem %"}, statsDialog.setStatsQuerySortBy)
+	statsDialog.podSortByDropDown.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// table
 	statsDialog.table = tview.NewTable()
@@ -104,6 +108,7 @@ func NewPodStatsDialog() *PodStatsDialog {
 		AddButton("Cancel", nil).
 		SetButtonsAlign(tview.AlignRight)
 	statsDialog.form.SetBackgroundColor(bgColor)
+	statsDialog.form.SetButtonBackgroundColor(utils.Styles.ButtonPrimitive.BgColor)
 
 	// pod dropdown and sort by dropdown
 	statsDialog.controlLayout = tview.NewFlex().SetDirection(tview.FlexColumn)

--- a/ui/system/sysdialogs/add.go
+++ b/ui/system/sysdialogs/add.go
@@ -47,6 +47,8 @@ func NewAddConnectionDialog() *AddConnectionDialog {
 
 	bgColor := utils.Styles.ConnectionAddDialog.BgColor
 	fgColor := utils.Styles.ConnectionAddDialog.FgColor
+	inputFieldBgColor := utils.Styles.InputFieldPrimitive.BgColor
+	buttonBackBgColor := utils.Styles.ButtonPrimitive.BgColor
 
 	labelWidth := 10
 	// connection name
@@ -55,6 +57,7 @@ func NewAddConnectionDialog() *AddConnectionDialog {
 	connDialog.connNameField.SetLabelWidth(labelWidth)
 	connDialog.connNameField.SetBackgroundColor(bgColor)
 	connDialog.connNameField.SetLabelColor(fgColor)
+	connDialog.connNameField.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// connection URI
 	connDialog.connURIField = tview.NewInputField()
@@ -62,6 +65,7 @@ func NewAddConnectionDialog() *AddConnectionDialog {
 	connDialog.connURIField.SetLabelWidth(labelWidth)
 	connDialog.connURIField.SetBackgroundColor(bgColor)
 	connDialog.connURIField.SetLabelColor(fgColor)
+	connDialog.connURIField.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// identity
 	connDialog.identityField = tview.NewInputField()
@@ -69,6 +73,7 @@ func NewAddConnectionDialog() *AddConnectionDialog {
 	connDialog.identityField.SetLabelWidth(labelWidth)
 	connDialog.identityField.SetBackgroundColor(bgColor)
 	connDialog.identityField.SetLabelColor(fgColor)
+	connDialog.identityField.SetFieldBackgroundColor(inputFieldBgColor)
 
 	// form
 	connDialog.form = tview.NewForm().
@@ -76,6 +81,7 @@ func NewAddConnectionDialog() *AddConnectionDialog {
 		AddButton("Add", nil).
 		SetButtonsAlign(tview.AlignRight)
 	connDialog.form.SetBackgroundColor(bgColor)
+	connDialog.form.SetButtonBackgroundColor(buttonBackBgColor)
 
 	// layouts
 	inputFieldLayout := tview.NewFlex().SetDirection(tview.FlexRow)

--- a/ui/system/sysdialogs/connect.go
+++ b/ui/system/sysdialogs/connect.go
@@ -36,31 +36,29 @@ func NewConnectDialog() *ConnectDialog {
 	}
 
 	// colors
-	boxFgColor := utils.Styles.PageTable.FgColor
-	boxBgColor := utils.Styles.PageTable.BgColor
+	borderColor := utils.Styles.ConnectionProgressDialog.BorderColor
+	titleColor := utils.Styles.ConnectionProgressDialog.TitleColor
 	connPrgFgColor := utils.Styles.ConnectionProgressDialog.FgColor
 	connPrgBgColor := utils.Styles.ConnectionProgressDialog.BgColor
 
 	// connect dialog box
-	conn.Box.SetBorderColor(boxBgColor)
-	conn.Box.SetTitleColor(boxFgColor)
 	conn.Box.SetBorder(false)
 
 	// progress bar
 	conn.progressDialog.SetPgBgColor(connPrgBgColor)
 	conn.progressDialog.SetBackgroundColor(connPrgBgColor)
-	conn.progressDialog.SetPgBgColor(connPrgFgColor)
+	conn.progressDialog.SetPgBgColor(utils.Styles.ConnectionProgressDialog.PrgBarColor)
 
 	// connection message text view
 	conn.textview.SetBackgroundColor(connPrgBgColor)
-	conn.textview.SetTextColor(boxFgColor)
+	conn.textview.SetTextColor(titleColor)
 
 	// cancel button and layout
 	conn.cancelButton.SetBackgroundColor(connPrgFgColor)
-	conn.cancelButton.SetLabelColor(connPrgFgColor)
+	conn.cancelButton.SetLabelColor(titleColor)
 	conn.cancelButton.SetLabelColorActivated(connPrgBgColor)
 	//conn.cancelButton.SetBackgroundColorActivated(connPrgFgColor)
-	conn.cancelButton.SetLabelColor(tcell.ColorBlack)
+
 	cancelLayout := tview.NewFlex().SetDirection(tview.FlexColumn)
 	cancelLayout.AddItem(utils.EmptyBoxSpace(connPrgBgColor), 0, 1, false)
 	cancelLayout.AddItem(conn.cancelButton, 10, 0, true)
@@ -69,6 +67,9 @@ func NewConnectDialog() *ConnectDialog {
 
 	// connection progress layout
 	conn.layout.SetBorder(true)
+	conn.layout.SetBorderColor(borderColor)
+	conn.layout.SetTitleColor(titleColor)
+
 	conn.layout.SetBackgroundColor(connPrgBgColor)
 	conn.layout.AddItem(utils.EmptyBoxSpace(connPrgBgColor), 1, 0, false)
 	conn.layout.AddItem(conn.progressDialog, 1, 0, false)

--- a/ui/system/sysdialogs/df.go
+++ b/ui/system/sysdialogs/df.go
@@ -34,7 +34,9 @@ func NewDfDialog() *DfDialog {
 		tableHeaders: []string{"type", "total", "active", "size", "reclaimable"},
 		display:      false,
 	}
-	bgColor := utils.Styles.CommandDialog.BgColor
+	bgColor := utils.Styles.DiskUageDialog.BgColor
+	buttonBgColor := utils.Styles.ButtonPrimitive.BgColor
+
 	dialog.table = tview.NewTable()
 	dialog.table.SetBackgroundColor(bgColor)
 	dialog.table.SetBorder(false)
@@ -44,6 +46,7 @@ func NewDfDialog() *DfDialog {
 		AddButton("Enter", nil).
 		SetButtonsAlign(tview.AlignRight)
 	dialog.form.SetBackgroundColor(bgColor)
+	dialog.form.SetButtonBackgroundColor(buttonBgColor)
 
 	dialog.layout = tview.NewFlex().SetDirection(tview.FlexRow)
 
@@ -144,8 +147,8 @@ func (d *DfDialog) SetDoneFunc(handler func()) *DfDialog {
 }
 
 func (d *DfDialog) initTable() {
-	bgColor := utils.Styles.CommandDialog.HeaderRow.BgColor
-	fgColor := utils.Styles.CommandDialog.HeaderRow.FgColor
+	bgColor := utils.Styles.DiskUageDialog.HeaderRow.BgColor
+	fgColor := utils.Styles.DiskUageDialog.HeaderRow.FgColor
 
 	d.table.Clear()
 	d.table.SetFixed(1, 1)

--- a/ui/system/sysdialogs/event.go
+++ b/ui/system/sysdialogs/event.go
@@ -37,6 +37,7 @@ func NewEventDialog() *EventsDialog {
 	bgColor := utils.Styles.EventsDialog.BgColor
 	textviewBgColor := utils.Styles.EventsDialog.EventViewer.BgColor
 	textviewFgColor := utils.Styles.EventsDialog.EventViewer.FgColor
+	buttonBgColor := utils.Styles.ButtonPrimitive.BgColor
 
 	// text view
 	eventsDialog.textview = tview.NewTextView().
@@ -55,6 +56,7 @@ func NewEventDialog() *EventsDialog {
 		SetButtonsAlign(tview.AlignRight)
 
 	eventsDialog.form.SetBackgroundColor(bgColor)
+	eventsDialog.form.SetButtonBackgroundColor(buttonBgColor)
 
 	// textview layout
 	tlayout := tview.NewFlex().SetDirection(tview.FlexColumn)

--- a/ui/utils/home.go
+++ b/ui/utils/home.go
@@ -1,0 +1,16 @@
+//go:build !windows
+// +build !windows
+
+package utils
+
+import "github.com/containers/storage/pkg/unshare"
+
+// UserHomeDir returns user's home directory
+func UserHomeDir() (string, error) {
+	// only get HomeDir when necessary
+	home, err := unshare.HomeDir()
+	if err != nil {
+		return "", err
+	}
+	return home, nil
+}

--- a/ui/utils/home_windows.go
+++ b/ui/utils/home_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+// +build windows
+
+package utils
+
+import (
+	"os"
+)
+
+// UserHomeDir returns user's home directory
+func UserHomeDir() (string, error) {
+	return os.UserHomeDir()
+}

--- a/ui/utils/style_windows.go
+++ b/ui/utils/style_windows.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build windows
+// +build windows
 
 package utils
 
@@ -11,21 +11,21 @@ import (
 // Styles represent default application style
 var Styles = theme{
 	PageTable: pageTable{
-		FgColor: tcell.ColorLightCyan,
-		BgColor: tcell.ColorLightSkyBlue,
+		FgColor: tcell.ColorPink,
+		BgColor: tcell.ColorPink,
 		HeaderRow: headerRow{
 			FgColor: tcell.ColorBlack,
-			BgColor: tcell.ColorSteelBlue,
+			BgColor: tcell.ColorPink,
 		},
 	},
 	InfoBar: infoBar{
-		ItemFgColor:  tcell.ColorLightSkyBlue,
+		ItemFgColor:  tcell.ColorPink,
 		ValueFgColor: tcell.ColorWhite,
 		ProgressBar: progressBar{
 			FgColor:       tcell.ColorWhite,
 			BarEmptyColor: tcell.ColorWhite,
-			BarOKColor:    tcell.ColorGreen,
-			BarWarnColor:  tcell.ColorOrange,
+			BarOKColor:    tcell.ColorLime,
+			BarWarnColor:  tcell.ColorYellow,
 			BarCritColor:  tcell.ColorRed,
 		},
 	},
@@ -34,117 +34,117 @@ var Styles = theme{
 		BgColor: tcell.ColorBlack,
 		Item: menuItem{
 			FgColor: tcell.ColorBlack,
-			BgColor: tcell.ColorSteelBlue,
+			BgColor: tcell.ColorPink,
 		},
 	},
 	Help: help{
-		BorderColor:   tcell.ColorLightSkyBlue,
+		BorderColor:   tcell.ColorPink,
 		BgColor:       tview.Styles.PrimitiveBackgroundColor,
 		FgColor:       tcell.ColorWhite,
-		HeaderFgColor: tcell.ColorSteelBlue,
+		HeaderFgColor: tcell.ColorPink,
 	},
 	ConnectionProgressDialog: connectionProgressDialog{
-		BgColor:     tcell.ColorOrangeRed,
-		FgColor:     tcell.ColorOrange,
-		PrgBarColor: tcell.ColorOrange,
-		BorderColor: tcell.ColorLightSkyBlue,
-		TitleColor:  tcell.ColorLightCyan,
+		BgColor:     tcell.ColorPink,
+		FgColor:     tcell.ColorPurple,
+		PrgBarColor: tcell.ColorFuchsia,
+		BorderColor: tcell.ColorWhite,
+		TitleColor:  tcell.ColorWhite,
 	},
 	CommandDialog: commandDialog{
-		BgColor: tcell.ColorSteelBlue,
+		BgColor: tcell.ColorPink,
 		FgColor: tcell.ColorWhite,
 		HeaderRow: headerRow{
 			FgColor: tcell.ColorWhite,
-			BgColor: tcell.ColorNavy,
+			BgColor: tcell.ColorPurple,
 		},
 	},
 	ConfirmDialog: confirmDialog{
-		BgColor: tcell.ColorOrange,
-		FgColor: tcell.ColorBlack,
+		BgColor: tcell.ColorPink,
+		FgColor: tcell.ColorWhite,
 	},
 	ImageSearchDialog: imageSearchDialog{
-		BgColor:                tcell.ColorSteelBlue,
+		BgColor:                tcell.ColorPink,
 		FgColor:                tcell.ColorWhite,
-		ResultTableBgColor:     tcell.ColorSteelBlue,
-		ResultTableBorderColor: tcell.ColorNavy,
+		ResultTableBgColor:     tview.Styles.PrimitiveBackgroundColor,
+		ResultTableBorderColor: tview.Styles.PrimaryTextColor,
 		ResultHeaderRow: headerRow{
 			FgColor: tcell.ColorWhite,
-			BgColor: tcell.ColorNavy,
+			BgColor: tcell.ColorPurple,
 		},
 	},
 	ImageHistoryDialog: imageHistoryDialog{
-		BgColor: tcell.ColorSteelBlue,
-		FgColor: tcell.ColorBlack,
+		BgColor: tcell.ColorPink,
+		FgColor: tcell.ColorWhite,
 		HeaderRow: headerRow{
 			FgColor: tcell.ColorWhite,
-			BgColor: tcell.ColorNavy,
+			BgColor: tcell.ColorPurple,
 		},
 	},
 	ImageImportDialog: imageImportDialog{
-		BgColor: tcell.ColorSteelBlue,
+		BgColor: tcell.ColorPink,
 		FgColor: tcell.ColorWhite,
 	},
 	ImageBuildDialog: imageBuildDialog{
-		BgColor: tcell.ColorSteelBlue,
+		BgColor: tcell.ColorPink,
 		FgColor: tcell.ColorWhite,
 	},
 	ImageBuildPrgDialog: imageBuildPrgDialog{
-		BgColor:      tcell.ColorSteelBlue,
+		BgColor:      tcell.ColorPink,
 		FgColor:      tcell.ColorWhite,
 		PrgCellColor: tcell.ColorOrange,
 		Terminal: terminal{
 			BgColor: tview.Styles.PrimitiveBackgroundColor,
-			FgColor: tcell.ColorWhite,
+			FgColor: tview.Styles.PrimaryTextColor,
 		},
 	},
 	ImageSaveDialog: imageSaveDialog{
-		BgColor: tcell.ColorSteelBlue,
+		BgColor: tcell.ColorPink,
 		FgColor: tcell.ColorWhite,
 	},
 	VolumeCreateDialog: volumeCreateDialog{
-		BgColor: tcell.ColorSteelBlue,
+		BgColor: tcell.ColorPink,
 		FgColor: tcell.ColorWhite,
 	},
 	NetworkCreateDialog: networkCreateDialog{
-		BgColor: tcell.ColorSteelBlue,
+		BgColor: tcell.ColorPink,
 		FgColor: tcell.ColorWhite,
 	},
 	ContainerCreateDialog: containerCreateDialog{
-		BgColor: tcell.ColorSteelBlue,
+		BgColor: tcell.ColorPink,
 		FgColor: tcell.ColorWhite,
 	},
 	ContainerExecDialog: containerExecDialog{
-		BgColor: tcell.ColorSteelBlue,
+		BgColor: tcell.ColorPink,
 		FgColor: tcell.ColorWhite,
 	},
 	ContainerExecTerminalDialog: containerExecTerminalDialog{
-		BgColor:       tcell.ColorSteelBlue,
+		BgColor:       tcell.ColorPink,
 		FgColor:       tcell.ColorWhite,
-		HeaderBgColor: tcell.ColorNavy,
+		HeaderBgColor: tcell.ColorPurple,
 		Terminal: terminal{
 			BgColor: tcell.NewRGBColor(0, 0, 0),
 			FgColor: tcell.NewRGBColor(255, 255, 255),
 		},
 	},
 	ContainerStatsDialog: containerStatsDialog{
-		TableHeaderFgColor: tcell.ColorLightSkyBlue,
-		BgColor:            tcell.ColorSteelBlue,
+		TableHeaderFgColor: tcell.ColorPink,
+		BgColor:            tcell.ColorPink,
 		FgColor:            tcell.ColorWhite,
 	},
 	PodCreateDialog: podCreateDialog{
-		BgColor: tcell.ColorSteelBlue,
+		BgColor: tcell.ColorPink,
 		FgColor: tcell.ColorWhite,
 	},
 	PodStatsDialog: podStatsDialog{
-		BgColor: tcell.ColorSteelBlue,
+		BgColor: tcell.ColorPink,
 		FgColor: tcell.ColorWhite,
 	},
 	DropdownStyle: dropdownStyle{
-		Unselected: tcell.StyleDefault.Background(tcell.ColorLightSkyBlue).Foreground(tcell.ColorBlack),
-		Selected:   tcell.StyleDefault.Background(tcell.ColorBlue).Foreground(tcell.ColorWhite),
+		Unselected: tcell.StyleDefault.Background(tcell.ColorFuchsia).Foreground(tcell.ColorBlack),
+		Selected:   tcell.StyleDefault.Background(tcell.ColorPurple).Foreground(tcell.ColorWhite),
 	},
 	EventsDialog: eventsDialog{
-		BgColor: tcell.ColorSteelBlue,
+		BgColor: tcell.ColorPink,
 		FgColor: tcell.ColorWhite,
 		EventViewer: terminal{
 			BgColor: tview.Styles.PrimitiveBackgroundColor,
@@ -152,19 +152,19 @@ var Styles = theme{
 		},
 	},
 	ConnectionAddDialog: connectionAddDialog{
-		BgColor: tcell.ColorSteelBlue,
+		BgColor: tcell.ColorPink,
 		FgColor: tcell.ColorWhite,
 	},
 	DiskUageDialog: diskUageDialog{
-		BgColor: tcell.ColorSteelBlue,
+		BgColor: tcell.ColorPink,
 		FgColor: tcell.ColorWhite,
 		HeaderRow: headerRow{
 			FgColor: tcell.ColorWhite,
-			BgColor: tcell.ColorNavy,
+			BgColor: tcell.ColorPurple,
 		},
 	},
 	MessageDialog: messageDialog{
-		BgColor: tcell.ColorSteelBlue,
+		BgColor: tcell.ColorPink,
 		FgColor: tcell.ColorWhite,
 		Terminal: terminal{
 			BgColor: tview.Styles.PrimitiveBackgroundColor,
@@ -172,21 +172,21 @@ var Styles = theme{
 		},
 	},
 	ButtonPrimitive: buttonPrimitive{
-		BgColor: tcell.ColorBlue,
+		BgColor: tcell.ColorPurple,
 	},
 	InputFieldPrimitive: inputFieldPrimitive{
-		BgColor: tcell.ColorBlue,
+		BgColor: tcell.ColorPurple,
 	},
 	ProgressDailog: progressDailog{
-		PgBarColor: tcell.ColorOrange,
+		PgBarColor: tcell.ColorPurple,
 	},
 	InputDialog: inputDialog{
-		BgColor: tcell.ColorSteelBlue,
+		BgColor: tcell.ColorPink,
 		FgColor: tcell.ColorWhite,
 	},
 	ErrorDialog: errorDialog{
-		HeaderFgColor: tcell.ColorDarkRed,
-		BgColor:       tcell.ColorOrangeRed,
+		HeaderFgColor: tcell.ColorOrangeRed,
+		BgColor:       tcell.ColorRed,
 		FgColor:       tcell.ColorWhite,
 	},
 }

--- a/ui/utils/theme.go
+++ b/ui/utils/theme.go
@@ -18,18 +18,32 @@ type theme struct {
 	ImageBuildDialog            imageBuildDialog
 	ImageBuildPrgDialog         imageBuildPrgDialog
 	ImageSaveDialog             imageSaveDialog
+	VolumeCreateDialog          volumeCreateDialog
+	NetworkCreateDialog         networkCreateDialog
+	ContainerCreateDialog       containerCreateDialog
 	ContainerExecDialog         containerExecDialog
 	ContainerExecTerminalDialog containerExecTerminalDialog
 	ContainerStatsDialog        containerStatsDialog
 	PodStatsDialog              podStatsDialog
+	PodCreateDialog             podCreateDialog
 	DropdownStyle               dropdownStyle
 	EventsDialog                eventsDialog
 	ConnectionAddDialog         connectionAddDialog
+	DiskUageDialog              diskUageDialog
+	MessageDialog               messageDialog
+	ButtonPrimitive             buttonPrimitive
+	InputFieldPrimitive         inputFieldPrimitive
+	ProgressDailog              progressDailog
+	InputDialog                 inputDialog
+	ErrorDialog                 errorDialog
 }
 
 type connectionProgressDialog struct {
-	BgColor tcell.Color
-	FgColor tcell.Color
+	BgColor     tcell.Color
+	FgColor     tcell.Color
+	BorderColor tcell.Color
+	TitleColor  tcell.Color
+	PrgBarColor tcell.Color
 }
 
 type infoBar struct {
@@ -120,15 +134,30 @@ type imageSaveDialog struct {
 	FgColor tcell.Color
 }
 
+type volumeCreateDialog struct {
+	BgColor tcell.Color
+	FgColor tcell.Color
+}
+
+type networkCreateDialog struct {
+	BgColor tcell.Color
+	FgColor tcell.Color
+}
+type containerCreateDialog struct {
+	BgColor tcell.Color
+	FgColor tcell.Color
+}
+
 type containerExecDialog struct {
 	BgColor tcell.Color
 	FgColor tcell.Color
 }
 
 type containerExecTerminalDialog struct {
-	BgColor  tcell.Color
-	FgColor  tcell.Color
-	Terminal terminal
+	BgColor       tcell.Color
+	FgColor       tcell.Color
+	HeaderBgColor tcell.Color
+	Terminal      terminal
 }
 
 type containerStatsDialog struct {
@@ -136,7 +165,13 @@ type containerStatsDialog struct {
 	BgColor            tcell.Color
 	FgColor            tcell.Color
 }
+
 type terminal struct {
+	BgColor tcell.Color
+	FgColor tcell.Color
+}
+
+type podCreateDialog struct {
 	BgColor tcell.Color
 	FgColor tcell.Color
 }
@@ -160,4 +195,39 @@ type eventsDialog struct {
 type connectionAddDialog struct {
 	FgColor tcell.Color
 	BgColor tcell.Color
+}
+
+type diskUageDialog struct {
+	BgColor   tcell.Color
+	FgColor   tcell.Color
+	HeaderRow headerRow
+}
+
+type messageDialog struct {
+	BgColor  tcell.Color
+	FgColor  tcell.Color
+	Terminal terminal
+}
+
+type buttonPrimitive struct {
+	BgColor tcell.Color
+}
+
+type inputFieldPrimitive struct {
+	BgColor tcell.Color
+}
+
+type progressDailog struct {
+	PgBarColor tcell.Color
+}
+
+type inputDialog struct {
+	BgColor tcell.Color
+	FgColor tcell.Color
+}
+
+type errorDialog struct {
+	HeaderFgColor tcell.Color
+	BgColor       tcell.Color
+	FgColor       tcell.Color
 }

--- a/ui/utils/utils.go
+++ b/ui/utils/utils.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/containers/storage/pkg/unshare"
 	"github.com/gdamore/tcell/v2"
 	"github.com/pkg/errors"
 	"github.com/rivo/tview"
@@ -76,7 +75,7 @@ func ResolveHomeDir(path string) (string, error) {
 	}
 
 	// only get HomeDir when necessary
-	home, err := unshare.HomeDir()
+	home, err := UserHomeDir()
 	if err != nil {
 		return "", err
 	}

--- a/ui/volumes/commands.go
+++ b/ui/volumes/commands.go
@@ -57,14 +57,14 @@ func (vols *Volumes) inspect() {
 }
 
 func (vols *Volumes) cprune() {
-	vols.confirmDialog.SetTitle("podman pod prune")
+	vols.confirmDialog.SetTitle("podman volume prune")
 	vols.confirmData = "prune"
 	vols.confirmDialog.SetText("Are you sure you want to remove all unused volumes ?")
 	vols.confirmDialog.Display()
 }
 
 func (vols *Volumes) prune() {
-	vols.progressDialog.SetTitle("pod purne in progress")
+	vols.progressDialog.SetTitle("VOLUME purne in progress")
 	vols.progressDialog.Display()
 	prune := func() {
 		errData, err := volumes.Prune()

--- a/ui/volumes/voldialogs/create.go
+++ b/ui/volumes/voldialogs/create.go
@@ -41,7 +41,7 @@ type VolumeCreateDialog struct {
 
 // NewVolumeCreateDialog returns new pod create dialog primitive VolumeCreateDialog
 func NewVolumeCreateDialog() *VolumeCreateDialog {
-	podDialog := VolumeCreateDialog{
+	volDialog := VolumeCreateDialog{
 		Box:                      tview.NewBox(),
 		layout:                   tview.NewFlex().SetDirection(tview.FlexRow),
 		form:                     tview.NewForm(),
@@ -52,57 +52,75 @@ func NewVolumeCreateDialog() *VolumeCreateDialog {
 		volumeDriverOptionsField: tview.NewInputField(),
 	}
 
-	bgColor := utils.Styles.ImageHistoryDialog.BgColor
+	bgColor := utils.Styles.VolumeCreateDialog.BgColor
+	fgColor := utils.Styles.VolumeCreateDialog.FgColor
+	buttonBgColor := utils.Styles.ButtonPrimitive.BgColor
+	inputFieldColor := utils.Styles.InputFieldPrimitive.BgColor
 
 	// basic information setup page
 	basicInfoPageLabelWidth := 9
 	// name field
-	podDialog.volumeNameField.SetLabel("name:")
-	podDialog.volumeNameField.SetLabelWidth(basicInfoPageLabelWidth)
-	podDialog.volumeNameField.SetBackgroundColor(bgColor)
-	podDialog.volumeNameField.SetLabelColor(tcell.ColorWhite)
+	volDialog.volumeNameField.SetLabel("name:")
+	volDialog.volumeNameField.SetLabelWidth(basicInfoPageLabelWidth)
+	volDialog.volumeNameField.SetBackgroundColor(bgColor)
+	volDialog.volumeNameField.SetLabelColor(fgColor)
+	volDialog.volumeNameField.SetFieldBackgroundColor(inputFieldColor)
 	// labels field
-	podDialog.volumeLabelField.SetLabel("labels:")
-	podDialog.volumeLabelField.SetLabelWidth(basicInfoPageLabelWidth)
-	podDialog.volumeLabelField.SetBackgroundColor(bgColor)
-	podDialog.volumeLabelField.SetLabelColor(tcell.ColorWhite)
+	volDialog.volumeLabelField.SetLabel("labels:")
+	volDialog.volumeLabelField.SetLabelWidth(basicInfoPageLabelWidth)
+	volDialog.volumeLabelField.SetBackgroundColor(bgColor)
+	volDialog.volumeLabelField.SetLabelColor(fgColor)
+	volDialog.volumeLabelField.SetFieldBackgroundColor(inputFieldColor)
 	// drivers
-	podDialog.volumeDriverField.SetLabel("drivers:")
-	podDialog.volumeDriverField.SetLabelWidth(basicInfoPageLabelWidth)
-	podDialog.volumeDriverField.SetBackgroundColor(bgColor)
-	podDialog.volumeDriverField.SetLabelColor(tcell.ColorWhite)
+	volDialog.volumeDriverField.SetLabel("drivers:")
+	volDialog.volumeDriverField.SetLabelWidth(basicInfoPageLabelWidth)
+	volDialog.volumeDriverField.SetBackgroundColor(bgColor)
+	volDialog.volumeDriverField.SetLabelColor(fgColor)
+	volDialog.volumeDriverField.SetFieldBackgroundColor(inputFieldColor)
 	// drivers options
-	podDialog.volumeDriverOptionsField.SetLabel("options:")
-	podDialog.volumeDriverOptionsField.SetLabelWidth(basicInfoPageLabelWidth)
-	podDialog.volumeDriverOptionsField.SetBackgroundColor(bgColor)
-	podDialog.volumeDriverOptionsField.SetLabelColor(tcell.ColorWhite)
+	volDialog.volumeDriverOptionsField.SetLabel("options:")
+	volDialog.volumeDriverOptionsField.SetLabelWidth(basicInfoPageLabelWidth)
+	volDialog.volumeDriverOptionsField.SetBackgroundColor(bgColor)
+	volDialog.volumeDriverOptionsField.SetLabelColor(fgColor)
+	volDialog.volumeDriverOptionsField.SetFieldBackgroundColor(inputFieldColor)
 
 	// form
-	podDialog.form.SetBackgroundColor(bgColor)
-	podDialog.form.AddButton("Cancel", nil)
-	podDialog.form.AddButton("Create", nil)
-	podDialog.form.SetButtonsAlign(tview.AlignRight)
+	volDialog.form.SetBackgroundColor(bgColor)
+	volDialog.form.AddButton("Cancel", nil)
+	volDialog.form.AddButton("Create", nil)
+	volDialog.form.SetButtonsAlign(tview.AlignRight)
+	volDialog.form.SetButtonBackgroundColor(buttonBgColor)
 
-	podDialog.setupLayout()
-	podDialog.layout.SetBackgroundColor(bgColor)
-	podDialog.layout.SetBorder(true)
-	podDialog.layout.SetTitle("PODMAN VOLUME CREATE")
+	volDialog.setupLayout()
+	volDialog.layout.SetBackgroundColor(bgColor)
+	volDialog.layout.SetBorder(true)
+	volDialog.layout.SetTitle("PODMAN VOLUME CREATE")
 
-	return &podDialog
+	return &volDialog
 }
 
 func (d *VolumeCreateDialog) setupLayout() {
-	bgColor := utils.Styles.ImageHistoryDialog.BgColor
+	bgColor := utils.Styles.VolumeCreateDialog.BgColor
 
-	// basic info page
-	d.layout.AddItem(utils.EmptyBoxSpace(bgColor), 1, 0, true)
-	d.layout.AddItem(d.volumeNameField, 1, 0, true)
-	d.layout.AddItem(utils.EmptyBoxSpace(bgColor), 1, 0, true)
-	d.layout.AddItem(d.volumeLabelField, 1, 0, true)
-	d.layout.AddItem(utils.EmptyBoxSpace(bgColor), 1, 0, true)
-	d.layout.AddItem(d.volumeDriverField, 1, 0, true)
-	d.layout.AddItem(utils.EmptyBoxSpace(bgColor), 1, 0, true)
-	d.layout.AddItem(d.volumeDriverOptionsField, 1, 0, true)
+	// layouts
+	inputFieldLayout := tview.NewFlex().SetDirection(tview.FlexRow)
+	inputFieldLayout.SetBackgroundColor(bgColor)
+	inputFieldLayout.AddItem(utils.EmptyBoxSpace(bgColor), 1, 0, true)
+	inputFieldLayout.AddItem(d.volumeNameField, 1, 0, true)
+	inputFieldLayout.AddItem(utils.EmptyBoxSpace(bgColor), 1, 0, true)
+	inputFieldLayout.AddItem(d.volumeLabelField, 1, 0, true)
+	inputFieldLayout.AddItem(utils.EmptyBoxSpace(bgColor), 1, 0, true)
+	inputFieldLayout.AddItem(d.volumeDriverField, 1, 0, true)
+	inputFieldLayout.AddItem(utils.EmptyBoxSpace(bgColor), 1, 0, true)
+	inputFieldLayout.AddItem(d.volumeDriverOptionsField, 1, 0, true)
+
+	// adding an empty column space to beginning and end of the fields layout
+	layout := tview.NewFlex().SetDirection(tview.FlexColumn)
+	layout.AddItem(utils.EmptyBoxSpace(bgColor), 1, 0, true)
+	layout.AddItem(inputFieldLayout, 0, 1, true)
+	layout.AddItem(utils.EmptyBoxSpace(bgColor), 1, 0, true)
+
+	d.layout.AddItem(layout, 0, 1, true)
 	d.layout.AddItem(d.form, dialogs.DialogFormHeight, 0, true)
 
 }


### PR DESCRIPTION
Adding support to build and run podman-tui under windows and its powershell terminal. 
It has been tested successfully under Windows 11 enterprise eval version (windows terminal v1.12).
Blue color didn't look good under windows terminal with limited color bits and therefore changed to purple/pink color (no change for Linux color style)

![podman-tui_win02](https://user-images.githubusercontent.com/5696685/163711497-79491086-075b-4f08-9a88-e24a14530359.png)

![Screenshot from 2022-04-17 21-02-13](https://user-images.githubusercontent.com/5696685/163711661-ca095e1e-f083-480b-a658-13c2ba6c0b82.png)


Signed-off-by: Navid Yaghoobi <n.yaghoobi.s@gmail.com>