### PR TITLE
exec terminal update (automatic resize and detach)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,9 @@ require (
 	github.com/docker/docker v20.10.14+incompatible
 	github.com/docker/go-units v0.4.0
 	github.com/gdamore/tcell/v2 v2.4.1-0.20210905002822-f057f0a857a1
+	github.com/hashicorp/go-multierror v1.1.1
+	github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02
 	github.com/navidys/tvxwidgets v0.1.0
-	github.com/navidys/vtterm v0.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/rivo/tview v0.0.0-20220307222120-9994674d60a8
 	github.com/rs/zerolog v1.26.1
@@ -57,7 +58,6 @@ require (
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gorilla/schema v1.2.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hpcloud/tail v1.0.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
@@ -76,6 +76,7 @@ require (
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/navidys/vtterm v0.1.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.3-0.20220114050600-8b9d41f48198 // indirect
 	github.com/opencontainers/runc v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -785,6 +785,8 @@ github.com/hashicorp/memberlist v0.3.0/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOn
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hashicorp/serf v0.9.5/go.mod h1:UWDWwZeL5cuWDJdl0C6wrvrUwEqtQ4ZKBKKENpqIUyk=
 github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
+github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02 h1:AgcIVYPa6XJnU3phs104wLj8l5GEththEw6+F79YsIY=
+github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.0.0/go.mod h1:4qWG/gcEcfX4z/mBDHJ++3ReCw9ibxbsNJbcucJdbSo=

--- a/pdcs/containers/exec.go
+++ b/pdcs/containers/exec.go
@@ -112,10 +112,10 @@ func Exec(sessionID string, opts ExecOption) {
 		return
 	}
 	log.Debug().Msgf("pdcs: podman session (%s) exec finished successfully", sessionID)
-	opts.OutputStream.Write([]byte(fmt.Sprintf("session_id ...... : %s\n", sessionID)))
-	opts.OutputStream.Write([]byte(fmt.Sprintf("exec_mode  ...... : %s\n", "detached")))
-	opts.OutputStream.Write([]byte(fmt.Sprintf("exec_command .... : %s\n", strings.Join(opts.Cmd, " "))))
-	opts.OutputStream.Write([]byte(fmt.Sprintf("exec_status ..... : %s\n", "OK")))
+	opts.OutputStream.Write([]byte(fmt.Sprintf("session_id ...... : %s\r\n", sessionID)))
+	opts.OutputStream.Write([]byte(fmt.Sprintf("exec_mode  ...... : %s\r\n", "detached")))
+	opts.OutputStream.Write([]byte(fmt.Sprintf("exec_command .... : %s\r\n", strings.Join(opts.Cmd, " "))))
+	opts.OutputStream.Write([]byte(fmt.Sprintf("exec_status ..... : %s\r\n", "OK")))
 }
 
 func genExecCreateConfig(opts ExecOption) (*handlers.ExecCreateConfig, error) {

--- a/test/005-container.bats
+++ b/test/005-container.bats
@@ -135,8 +135,8 @@ load helpers_tui
     podman_tui_select_item $container_index
     podman_tui_select_container_cmd "exec"
     podman_tui_send_inputs "/bin/bash"
-    podman_tui_send_inputs "Tab" "Space" "Tab" "Space"
-    podman_tui_send_inputs "Tab" "Tab" "Tab" "Tab" "Tab" "Tab" "Tab" "Tab" "Tab"
+    podman_tui_send_inputs "Tab" "Space" "Tab"
+    podman_tui_send_inputs "Tab" "Tab" "Tab" "Tab" "Tab" "Tab" "Tab" "Tab"
     podman_tui_send_inputs "Enter"
     sleep 1
     podman_tui_send_inputs "echo Space test Space > Space a.txt" "Enter"

--- a/test/helpers_tui.bash
+++ b/test/helpers_tui.bash
@@ -92,8 +92,10 @@ function podman_tui_select_image_cmd() {
     menu_index=8;;
   "tag")
     menu_index=9;;
-  "untag")
+  "tree")
     menu_index=10;;
+  "untag")
+    menu_index=11;;
   esac
 
   podman_tui_select_menu $menu_index

--- a/ui/containers/commands.go
+++ b/ui/containers/commands.go
@@ -104,13 +104,25 @@ func (cnt *Containers) exec() {
 	execOpts.TtyWidth = width
 	execOpts.TtyHeight = height
 
-	sessionID, err := cnt.execTerminalDialog.PrepareForExec(cnt.selectedID, cnt.selectedName, &execOpts)
+	err := cnt.execTerminalDialog.PrepareForExec(cnt.selectedID, cnt.selectedName, &execOpts)
 	if err != nil {
 		title := fmt.Sprintf("CONTAINER (%s) EXEC ERROR", cnt.selectedID)
 		cnt.displayError(title, err)
 		return
 	}
-	go containers.Exec(sessionID, execOpts)
+
+	prepareAndExec := func() {
+		execSessionID, err := containers.NewExecSession(cnt.selectedID, execOpts)
+		if err != nil {
+			title := fmt.Sprintf("CONTAINER (%s) EXEC ERROR", cnt.selectedID)
+			cnt.displayError(title, err)
+			return
+		}
+		cnt.execTerminalDialog.SetExecInfo(cnt.selectedID, cnt.selectedName, execSessionID)
+		containers.Exec(execSessionID, execOpts)
+	}
+	go prepareAndExec()
+
 	cnt.execTerminalDialog.Display()
 
 }

--- a/vendor/github.com/hinshun/vt10x/.travis.yml
+++ b/vendor/github.com/hinshun/vt10x/.travis.yml
@@ -1,0 +1,5 @@
+language: go
+
+go:
+  - "1.10.2"
+  - master

--- a/vendor/github.com/hinshun/vt10x/LICENSE
+++ b/vendor/github.com/hinshun/vt10x/LICENSE
@@ -1,0 +1,19 @@
+Copyright (C) 2013 James Gray
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without liitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and thismssion notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/hinshun/vt10x/README.md
+++ b/vendor/github.com/hinshun/vt10x/README.md
@@ -1,0 +1,9 @@
+# vt10x
+
+[![Build Status](https://travis-ci.org/hinshun/vt10x.svg?branch=master)](https://travis-ci.org/hinshun/vt10x)
+[![GoDoc](https://godoc.org/github.com/hinshun/vt10x?status.svg)](https://godoc.org/github.com/hinshun/vt10x)
+
+Package vt10x is a vt10x terminal emulation backend, influenced
+largely by st, rxvt, xterm, and iTerm as reference. Use it for terminal
+muxing, a terminal emulation frontend, or wherever else you need
+terminal emulation.

--- a/vendor/github.com/hinshun/vt10x/color.go
+++ b/vendor/github.com/hinshun/vt10x/color.go
@@ -1,0 +1,38 @@
+package vt10x
+
+// ANSI color values
+const (
+	Black Color = iota
+	Red
+	Green
+	Yellow
+	Blue
+	Magenta
+	Cyan
+	LightGrey
+	DarkGrey
+	LightRed
+	LightGreen
+	LightYellow
+	LightBlue
+	LightMagenta
+	LightCyan
+	White
+)
+
+// Default colors are potentially distinct to allow for special behavior.
+// For example, a transparent background. Otherwise, the simple case is to
+// map default colors to another color.
+const (
+	DefaultFG Color = 1<<24 + iota
+	DefaultBG
+	DefaultCursor
+)
+
+// Color maps to the ANSI colors [0, 16) and the xterm colors [16, 256).
+type Color uint32
+
+// ANSI returns true if Color is within [0, 16).
+func (c Color) ANSI() bool {
+	return (c < 16)
+}

--- a/vendor/github.com/hinshun/vt10x/csi.go
+++ b/vendor/github.com/hinshun/vt10x/csi.go
@@ -1,0 +1,189 @@
+package vt10x
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// CSI (Control Sequence Introducer)
+// ESC+[
+type csiEscape struct {
+	buf  []byte
+	args []int
+	mode byte
+	priv bool
+}
+
+func (c *csiEscape) reset() {
+	c.buf = c.buf[:0]
+	c.args = c.args[:0]
+	c.mode = 0
+	c.priv = false
+}
+
+func (c *csiEscape) put(b byte) bool {
+	c.buf = append(c.buf, b)
+	if b >= 0x40 && b <= 0x7E || len(c.buf) >= 256 {
+		c.parse()
+		return true
+	}
+	return false
+}
+
+func (c *csiEscape) parse() {
+	c.mode = c.buf[len(c.buf)-1]
+	if len(c.buf) == 1 {
+		return
+	}
+	s := string(c.buf)
+	c.args = c.args[:0]
+	if s[0] == '?' {
+		c.priv = true
+		s = s[1:]
+	}
+	s = s[:len(s)-1]
+	ss := strings.Split(s, ";")
+	for _, p := range ss {
+		i, err := strconv.Atoi(p)
+		if err != nil {
+			//t.logf("invalid CSI arg '%s'\n", p)
+			break
+		}
+		c.args = append(c.args, i)
+	}
+}
+
+func (c *csiEscape) arg(i, def int) int {
+	if i >= len(c.args) || i < 0 {
+		return def
+	}
+	return c.args[i]
+}
+
+// maxarg takes the maximum of arg(i, def) and def
+func (c *csiEscape) maxarg(i, def int) int {
+	return max(c.arg(i, def), def)
+}
+
+func (t *State) handleCSI() {
+	c := &t.csi
+	switch c.mode {
+	default:
+		goto unknown
+	case '@': // ICH - insert <n> blank char
+		t.insertBlanks(c.arg(0, 1))
+	case 'A': // CUU - cursor <n> up
+		t.moveTo(t.cur.X, t.cur.Y-c.maxarg(0, 1))
+	case 'B', 'e': // CUD, VPR - cursor <n> down
+		t.moveTo(t.cur.X, t.cur.Y+c.maxarg(0, 1))
+	case 'c': // DA - device attributes
+		if c.arg(0, 0) == 0 {
+			// TODO: write vt102 id
+		}
+	case 'C', 'a': // CUF, HPR - cursor <n> forward
+		t.moveTo(t.cur.X+c.maxarg(0, 1), t.cur.Y)
+	case 'D': // CUB - cursor <n> backward
+		t.moveTo(t.cur.X-c.maxarg(0, 1), t.cur.Y)
+	case 'E': // CNL - cursor <n> down and first col
+		t.moveTo(0, t.cur.Y+c.arg(0, 1))
+	case 'F': // CPL - cursor <n> up and first col
+		t.moveTo(0, t.cur.Y-c.arg(0, 1))
+	case 'g': // TBC - tabulation clear
+		switch c.arg(0, 0) {
+		// clear current tab stop
+		case 0:
+			t.tabs[t.cur.X] = false
+		// clear all tabs
+		case 3:
+			for i := range t.tabs {
+				t.tabs[i] = false
+			}
+		default:
+			goto unknown
+		}
+	case 'G', '`': // CHA, HPA - Move to <col>
+		t.moveTo(c.arg(0, 1)-1, t.cur.Y)
+	case 'H', 'f': // CUP, HVP - move to <row> <col>
+		t.moveAbsTo(c.arg(1, 1)-1, c.arg(0, 1)-1)
+	case 'I': // CHT - cursor forward tabulation <n> tab stops
+		n := c.arg(0, 1)
+		for i := 0; i < n; i++ {
+			t.putTab(true)
+		}
+	case 'J': // ED - clear screen
+		// TODO: sel.ob.x = -1
+		switch c.arg(0, 0) {
+		case 0: // below
+			t.clear(t.cur.X, t.cur.Y, t.cols-1, t.cur.Y)
+			if t.cur.Y < t.rows-1 {
+				t.clear(0, t.cur.Y+1, t.cols-1, t.rows-1)
+			}
+		case 1: // above
+			if t.cur.Y > 1 {
+				t.clear(0, 0, t.cols-1, t.cur.Y-1)
+			}
+			t.clear(0, t.cur.Y, t.cur.X, t.cur.Y)
+		case 2: // all
+			t.clear(0, 0, t.cols-1, t.rows-1)
+		default:
+			goto unknown
+		}
+	case 'K': // EL - clear line
+		switch c.arg(0, 0) {
+		case 0: // right
+			t.clear(t.cur.X, t.cur.Y, t.cols-1, t.cur.Y)
+		case 1: // left
+			t.clear(0, t.cur.Y, t.cur.X, t.cur.Y)
+		case 2: // all
+			t.clear(0, t.cur.Y, t.cols-1, t.cur.Y)
+		}
+	case 'S': // SU - scroll <n> lines up
+		t.scrollUp(t.top, c.arg(0, 1))
+	case 'T': // SD - scroll <n> lines down
+		t.scrollDown(t.top, c.arg(0, 1))
+	case 'L': // IL - insert <n> blank lines
+		t.insertBlankLines(c.arg(0, 1))
+	case 'l': // RM - reset mode
+		t.setMode(c.priv, false, c.args)
+	case 'M': // DL - delete <n> lines
+		t.deleteLines(c.arg(0, 1))
+	case 'X': // ECH - erase <n> chars
+		t.clear(t.cur.X, t.cur.Y, t.cur.X+c.arg(0, 1)-1, t.cur.Y)
+	case 'P': // DCH - delete <n> chars
+		t.deleteChars(c.arg(0, 1))
+	case 'Z': // CBT - cursor backward tabulation <n> tab stops
+		n := c.arg(0, 1)
+		for i := 0; i < n; i++ {
+			t.putTab(false)
+		}
+	case 'd': // VPA - move to <row>
+		t.moveAbsTo(t.cur.X, c.arg(0, 1)-1)
+	case 'h': // SM - set terminal mode
+		t.setMode(c.priv, true, c.args)
+	case 'm': // SGR - terminal attribute (color)
+		t.setAttr(c.args)
+	case 'n':
+		switch c.arg(0, 0) {
+		case 5: // DSR - device status report
+			t.w.Write([]byte("\033[0n"))
+		case 6: // CPR - cursor position report
+			t.w.Write([]byte(fmt.Sprintf("\033[%d;%dR", t.cur.Y+1, t.cur.X+1)))
+		}
+	case 'r': // DECSTBM - set scrolling region
+		if c.priv {
+			goto unknown
+		} else {
+			t.setScroll(c.arg(0, 1)-1, c.arg(1, t.rows)-1)
+			t.moveAbsTo(0, 0)
+		}
+	case 's': // DECSC - save cursor position (ANSI.SYS)
+		t.saveCursor()
+	case 'u': // DECRC - restore cursor position (ANSI.SYS)
+		t.restoreCursor()
+	}
+	return
+unknown: // TODO: get rid of this goto
+	t.logf("unknown CSI sequence '%c'\n", c.mode)
+	// TODO: c.dump()
+}

--- a/vendor/github.com/hinshun/vt10x/doc.go
+++ b/vendor/github.com/hinshun/vt10x/doc.go
@@ -1,0 +1,9 @@
+/*
+Package terminal is a vt10x terminal emulation backend, influenced
+largely by st, rxvt, xterm, and iTerm as reference. Use it for terminal
+muxing, a terminal emulation frontend, or wherever else you need
+terminal emulation.
+
+In development, but very usable.
+*/
+package vt10x

--- a/vendor/github.com/hinshun/vt10x/ioctl_other.go
+++ b/vendor/github.com/hinshun/vt10x/ioctl_other.go
@@ -1,0 +1,15 @@
+// +build plan9 nacl windows
+
+package vt10x
+
+import (
+	"os"
+)
+
+func ioctl(f *os.File, cmd, p uintptr) error {
+	return nil
+}
+
+func ResizePty(*os.File) error {
+	return nil
+}

--- a/vendor/github.com/hinshun/vt10x/ioctl_posix.go
+++ b/vendor/github.com/hinshun/vt10x/ioctl_posix.go
@@ -1,0 +1,31 @@
+// +build linux darwin dragonfly solaris openbsd netbsd freebsd
+
+package vt10x
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func ioctl(f *os.File, cmd, p uintptr) error {
+	_, _, errno := syscall.Syscall(
+		syscall.SYS_IOCTL,
+		f.Fd(),
+		syscall.TIOCSWINSZ,
+		p)
+	if errno != 0 {
+		return syscall.Errno(errno)
+	}
+	return nil
+}
+
+func ResizePty(pty *os.File, cols, rows int) error {
+	var w struct{ row, col, xpix, ypix uint16 }
+	w.row = uint16(rows)
+	w.col = uint16(cols)
+	w.xpix = 16 * uint16(cols)
+	w.ypix = 16 * uint16(rows)
+	return ioctl(pty, syscall.TIOCSWINSZ,
+		uintptr(unsafe.Pointer(&w)))
+}

--- a/vendor/github.com/hinshun/vt10x/parse.go
+++ b/vendor/github.com/hinshun/vt10x/parse.go
@@ -1,0 +1,203 @@
+package vt10x
+
+func isControlCode(c rune) bool {
+	return c < 0x20 || c == 0177
+}
+
+func (t *State) parse(c rune) {
+	t.logf("%q", string(c))
+	if isControlCode(c) {
+		if t.handleControlCodes(c) || t.cur.Attr.Mode&attrGfx == 0 {
+			return
+		}
+	}
+	// TODO: update selection; see st.c:2450
+
+	if t.mode&ModeWrap != 0 && t.cur.State&cursorWrapNext != 0 {
+		t.lines[t.cur.Y][t.cur.X].Mode |= attrWrap
+		t.newline(true)
+	}
+
+	if t.mode&ModeInsert != 0 && t.cur.X+1 < t.cols {
+		// TODO: move shiz, look at st.c:2458
+		t.logln("insert mode not implemented")
+	}
+
+	t.setChar(c, &t.cur.Attr, t.cur.X, t.cur.Y)
+	if t.cur.X+1 < t.cols {
+		t.moveTo(t.cur.X+1, t.cur.Y)
+	} else {
+		t.cur.State |= cursorWrapNext
+	}
+}
+
+func (t *State) parseEsc(c rune) {
+	if t.handleControlCodes(c) {
+		return
+	}
+	next := t.parse
+	t.logf("%q", string(c))
+	switch c {
+	case '[':
+		next = t.parseEscCSI
+	case '#':
+		next = t.parseEscTest
+	case 'P', // DCS - Device Control String
+		'_', // APC - Application Program Command
+		'^', // PM - Privacy Message
+		']', // OSC - Operating System Command
+		'k': // old title set compatibility
+		t.str.reset()
+		t.str.typ = c
+		next = t.parseEscStr
+	case '(': // set primary charset G0
+		next = t.parseEscAltCharset
+	case ')', // set secondary charset G1 (ignored)
+		'*', // set tertiary charset G2 (ignored)
+		'+': // set quaternary charset G3 (ignored)
+	case 'D': // IND - linefeed
+		if t.cur.Y == t.bottom {
+			t.scrollUp(t.top, 1)
+		} else {
+			t.moveTo(t.cur.X, t.cur.Y+1)
+		}
+	case 'E': // NEL - next line
+		t.newline(true)
+	case 'H': // HTS - horizontal tab stop
+		t.tabs[t.cur.X] = true
+	case 'M': // RI - reverse index
+		if t.cur.Y == t.top {
+			t.scrollDown(t.top, 1)
+		} else {
+			t.moveTo(t.cur.X, t.cur.Y-1)
+		}
+	case 'Z': // DECID - identify terminal
+		// TODO: write to our writer our id
+	case 'c': // RIS - reset to initial state
+		t.reset()
+	case '=': // DECPAM - application keypad
+		t.mode |= ModeAppKeypad
+	case '>': // DECPNM - normal keypad
+		t.mode &^= ModeAppKeypad
+	case '7': // DECSC - save cursor
+		t.saveCursor()
+	case '8': // DECRC - restore cursor
+		t.restoreCursor()
+	case '\\': // ST - stop
+	default:
+		t.logf("unknown ESC sequence '%c'\n", c)
+	}
+	t.state = next
+}
+
+func (t *State) parseEscCSI(c rune) {
+	if t.handleControlCodes(c) {
+		return
+	}
+	t.logf("%q", string(c))
+	if t.csi.put(byte(c)) {
+		t.state = t.parse
+		t.handleCSI()
+	}
+}
+
+func (t *State) parseEscStr(c rune) {
+	t.logf("%q", string(c))
+	switch c {
+	case '\033':
+		t.state = t.parseEscStrEnd
+	case '\a': // backwards compatiblity to xterm
+		t.state = t.parse
+		t.handleSTR()
+	default:
+		t.str.put(c)
+	}
+}
+
+func (t *State) parseEscStrEnd(c rune) {
+	if t.handleControlCodes(c) {
+		return
+	}
+	t.logf("%q", string(c))
+	t.state = t.parse
+	if c == '\\' {
+		t.handleSTR()
+	}
+}
+
+func (t *State) parseEscAltCharset(c rune) {
+	if t.handleControlCodes(c) {
+		return
+	}
+	t.logf("%q", string(c))
+	switch c {
+	case '0': // line drawing set
+		t.cur.Attr.Mode |= attrGfx
+	case 'B': // USASCII
+		t.cur.Attr.Mode &^= attrGfx
+	case 'A', // UK (ignored)
+		'<', // multinational (ignored)
+		'5', // Finnish (ignored)
+		'C', // Finnish (ignored)
+		'K': // German (ignored)
+	default:
+		t.logf("unknown alt. charset '%c'\n", c)
+	}
+	t.state = t.parse
+}
+
+func (t *State) parseEscTest(c rune) {
+	if t.handleControlCodes(c) {
+		return
+	}
+	// DEC screen alignment test
+	if c == '8' {
+		for y := 0; y < t.rows; y++ {
+			for x := 0; x < t.cols; x++ {
+				t.setChar('E', &t.cur.Attr, x, y)
+			}
+		}
+	}
+	t.state = t.parse
+}
+
+func (t *State) handleControlCodes(c rune) bool {
+	if !isControlCode(c) {
+		return false
+	}
+	switch c {
+	// HT
+	case '\t':
+		t.putTab(true)
+	// BS
+	case '\b':
+		t.moveTo(t.cur.X-1, t.cur.Y)
+	// CR
+	case '\r':
+		t.moveTo(0, t.cur.Y)
+	// LF, VT, LF
+	case '\f', '\v', '\n':
+		// go to first col if mode is set
+		t.newline(t.mode&ModeCRLF != 0)
+	// BEL
+	case '\a':
+		// TODO: emit sound
+		// TODO: window alert if not focused
+	// ESC
+	case 033:
+		t.csi.reset()
+		t.state = t.parseEsc
+	// SO, SI
+	case 016, 017:
+		// different charsets not supported. apps should use the correct
+		// alt charset escapes, probably for line drawing
+	// SUB, CAN
+	case 032, 030:
+		t.csi.reset()
+	// ignore ENQ, NUL, XON, XOFF, DEL
+	case 005, 000, 021, 023, 0177:
+	default:
+		return false
+	}
+	return true
+}

--- a/vendor/github.com/hinshun/vt10x/state.go
+++ b/vendor/github.com/hinshun/vt10x/state.go
@@ -1,0 +1,762 @@
+package vt10x
+
+import (
+	"io"
+	"log"
+	"sync"
+)
+
+const (
+	tabspaces = 8
+)
+
+const (
+	attrReverse = 1 << iota
+	attrUnderline
+	attrBold
+	attrGfx
+	attrItalic
+	attrBlink
+	attrWrap
+)
+
+const (
+	cursorDefault = 1 << iota
+	cursorWrapNext
+	cursorOrigin
+)
+
+// ModeFlag represents various terminal mode states.
+type ModeFlag uint32
+
+// Terminal modes
+const (
+	ModeWrap ModeFlag = 1 << iota
+	ModeInsert
+	ModeAppKeypad
+	ModeAltScreen
+	ModeCRLF
+	ModeMouseButton
+	ModeMouseMotion
+	ModeReverse
+	ModeKeyboardLock
+	ModeHide
+	ModeEcho
+	ModeAppCursor
+	ModeMouseSgr
+	Mode8bit
+	ModeBlink
+	ModeFBlink
+	ModeFocus
+	ModeMouseX10
+	ModeMouseMany
+	ModeMouseMask = ModeMouseButton | ModeMouseMotion | ModeMouseX10 | ModeMouseMany
+)
+
+// ChangeFlag represents possible state changes of the terminal.
+type ChangeFlag uint32
+
+// Terminal changes to occur in VT.ReadState
+const (
+	ChangedScreen ChangeFlag = 1 << iota
+	ChangedTitle
+)
+
+type Glyph struct {
+	Char   rune
+	Mode   int16
+	FG, BG Color
+}
+
+type line []Glyph
+
+type Cursor struct {
+	Attr  Glyph
+	X, Y  int
+	State uint8
+}
+
+type parseState func(c rune)
+
+// State represents the terminal emulation state. Use Lock/Unlock
+// methods to synchronize data access with VT.
+type State struct {
+	DebugLogger *log.Logger
+
+	w             io.Writer
+	mu            sync.Mutex
+	changed       ChangeFlag
+	cols, rows    int
+	lines         []line
+	altLines      []line
+	dirty         []bool // line dirtiness
+	anydirty      bool
+	cur, curSaved Cursor
+	top, bottom   int // scroll limits
+	mode          ModeFlag
+	state         parseState
+	str           strEscape
+	csi           csiEscape
+	numlock       bool
+	tabs          []bool
+	title         string
+	colorOverride map[Color]Color
+}
+
+func newState(w io.Writer) *State {
+	return &State{
+		w:             w,
+		colorOverride: make(map[Color]Color),
+	}
+}
+
+func (t *State) logf(format string, args ...interface{}) {
+	if t.DebugLogger != nil {
+		t.DebugLogger.Printf(format, args...)
+	}
+}
+
+func (t *State) logln(s string) {
+	if t.DebugLogger != nil {
+		t.DebugLogger.Println(s)
+	}
+}
+
+func (t *State) lock() {
+	t.mu.Lock()
+}
+
+func (t *State) unlock() {
+	t.mu.Unlock()
+}
+
+// Lock locks the state object's mutex.
+func (t *State) Lock() {
+	t.mu.Lock()
+}
+
+// Unlock resets change flags and unlocks the state object's mutex.
+func (t *State) Unlock() {
+	t.resetChanges()
+	t.mu.Unlock()
+}
+
+// Cell returns the glyph containing the character code, foreground color, and
+// background color at position (x, y) relative to the top left of the terminal.
+func (t *State) Cell(x, y int) Glyph {
+	cell := t.lines[y][x]
+	fg, ok := t.colorOverride[cell.FG]
+	if ok {
+		cell.FG = fg
+	}
+	bg, ok := t.colorOverride[cell.BG]
+	if ok {
+		cell.BG = bg
+	}
+	return cell
+}
+
+// Cursor returns the current position of the cursor.
+func (t *State) Cursor() Cursor {
+	return t.cur
+}
+
+// CursorVisible returns the visible state of the cursor.
+func (t *State) CursorVisible() bool {
+	return t.mode&ModeHide == 0
+}
+
+// Mode returns the current terminal mode.
+func (t *State) Mode() ModeFlag {
+	return t.mode
+}
+
+// Title returns the current title set via the tty.
+func (t *State) Title() string {
+	return t.title
+}
+
+/*
+// ChangeMask returns a bitfield of changes that have occured by VT.
+func (t *State) ChangeMask() ChangeFlag {
+	return t.changed
+}
+*/
+
+// Changed returns true if change has occured.
+func (t *State) Changed(change ChangeFlag) bool {
+	return t.changed&change != 0
+}
+
+// resetChanges resets the change mask and dirtiness.
+func (t *State) resetChanges() {
+	for i := range t.dirty {
+		t.dirty[i] = false
+	}
+	t.anydirty = false
+	t.changed = 0
+}
+
+func (t *State) saveCursor() {
+	t.curSaved = t.cur
+}
+
+func (t *State) restoreCursor() {
+	t.cur = t.curSaved
+	t.moveTo(t.cur.X, t.cur.Y)
+}
+
+func (t *State) put(c rune) {
+	t.state(c)
+}
+
+func (t *State) putTab(forward bool) {
+	x := t.cur.X
+	if forward {
+		if x == t.cols {
+			return
+		}
+		for x++; x < t.cols && !t.tabs[x]; x++ {
+		}
+	} else {
+		if x == 0 {
+			return
+		}
+		for x--; x > 0 && !t.tabs[x]; x-- {
+		}
+	}
+	t.moveTo(x, t.cur.Y)
+}
+
+func (t *State) newline(firstCol bool) {
+	y := t.cur.Y
+	if y == t.bottom {
+		cur := t.cur
+		t.cur = t.defaultCursor()
+		t.scrollUp(t.top, 1)
+		t.cur = cur
+	} else {
+		y++
+	}
+	if firstCol {
+		t.moveTo(0, y)
+	} else {
+		t.moveTo(t.cur.X, y)
+	}
+}
+
+// table from st, which in turn is from rxvt :)
+var gfxCharTable = [62]rune{
+	'↑', '↓', '→', '←', '█', '▚', '☃', // A - G
+	0, 0, 0, 0, 0, 0, 0, 0, // H - O
+	0, 0, 0, 0, 0, 0, 0, 0, // P - W
+	0, 0, 0, 0, 0, 0, 0, ' ', // X - _
+	'◆', '▒', '␉', '␌', '␍', '␊', '°', '±', // ` - g
+	'␤', '␋', '┘', '┐', '┌', '└', '┼', '⎺', // h - o
+	'⎻', '─', '⎼', '⎽', '├', '┤', '┴', '┬', // p - w
+	'│', '≤', '≥', 'π', '≠', '£', '·', // x - ~
+}
+
+func (t *State) setChar(c rune, attr *Glyph, x, y int) {
+	if attr.Mode&attrGfx != 0 {
+		if c >= 0x41 && c <= 0x7e && gfxCharTable[c-0x41] != 0 {
+			c = gfxCharTable[c-0x41]
+		}
+	}
+	t.changed |= ChangedScreen
+	t.dirty[y] = true
+	t.lines[y][x] = *attr
+	t.lines[y][x].Char = c
+	//if t.options.BrightBold && attr.Mode&attrBold != 0 && attr.FG < 8 {
+	if attr.Mode&attrBold != 0 && attr.FG < 8 {
+		t.lines[y][x].FG = attr.FG + 8
+	}
+	if attr.Mode&attrReverse != 0 {
+		t.lines[y][x].FG = attr.BG
+		t.lines[y][x].BG = attr.FG
+	}
+}
+
+func (t *State) defaultCursor() Cursor {
+	c := Cursor{}
+	c.Attr.FG = DefaultFG
+	c.Attr.BG = DefaultBG
+	return c
+}
+
+func (t *State) reset() {
+	t.cur = t.defaultCursor()
+	t.saveCursor()
+	for i := range t.tabs {
+		t.tabs[i] = false
+	}
+	for i := tabspaces; i < len(t.tabs); i += tabspaces {
+		t.tabs[i] = true
+	}
+	t.top = 0
+	t.bottom = t.rows - 1
+	t.mode = ModeWrap
+	t.clear(0, 0, t.rows-1, t.cols-1)
+	t.moveTo(0, 0)
+}
+
+// TODO: definitely can improve allocs
+func (t *State) resize(cols, rows int) bool {
+	if cols == t.cols && rows == t.rows {
+		return false
+	}
+	if cols < 1 || rows < 1 {
+		return false
+	}
+	slide := t.cur.Y - rows + 1
+	if slide > 0 {
+		copy(t.lines, t.lines[slide:slide+rows])
+		copy(t.altLines, t.altLines[slide:slide+rows])
+	}
+
+	lines, altLines, tabs := t.lines, t.altLines, t.tabs
+	t.lines = make([]line, rows)
+	t.altLines = make([]line, rows)
+	t.dirty = make([]bool, rows)
+	t.tabs = make([]bool, cols)
+
+	minrows := min(rows, t.rows)
+	mincols := min(cols, t.cols)
+	t.changed |= ChangedScreen
+	for i := 0; i < rows; i++ {
+		t.dirty[i] = true
+		t.lines[i] = make(line, cols)
+		t.altLines[i] = make(line, cols)
+	}
+	for i := 0; i < minrows; i++ {
+		copy(t.lines[i], lines[i])
+		copy(t.altLines[i], altLines[i])
+	}
+	copy(t.tabs, tabs)
+	if cols > t.cols {
+		i := t.cols - 1
+		for i > 0 && !tabs[i] {
+			i--
+		}
+		for i += tabspaces; i < len(tabs); i += tabspaces {
+			tabs[i] = true
+		}
+	}
+
+	t.cols = cols
+	t.rows = rows
+	t.setScroll(0, rows-1)
+	t.moveTo(t.cur.X, t.cur.Y)
+	for i := 0; i < 2; i++ {
+		if mincols < cols && minrows > 0 {
+			t.clear(mincols, 0, cols-1, minrows-1)
+		}
+		if cols > 0 && minrows < rows {
+			t.clear(0, minrows, cols-1, rows-1)
+		}
+		t.swapScreen()
+	}
+	return slide > 0
+}
+
+func (t *State) clear(x0, y0, x1, y1 int) {
+	if x0 > x1 {
+		x0, x1 = x1, x0
+	}
+	if y0 > y1 {
+		y0, y1 = y1, y0
+	}
+	x0 = clamp(x0, 0, t.cols-1)
+	x1 = clamp(x1, 0, t.cols-1)
+	y0 = clamp(y0, 0, t.rows-1)
+	y1 = clamp(y1, 0, t.rows-1)
+	t.changed |= ChangedScreen
+	for y := y0; y <= y1; y++ {
+		t.dirty[y] = true
+		for x := x0; x <= x1; x++ {
+			t.lines[y][x] = t.cur.Attr
+			t.lines[y][x].Char = ' '
+		}
+	}
+}
+
+func (t *State) clearAll() {
+	t.clear(0, 0, t.cols-1, t.rows-1)
+}
+
+func (t *State) moveAbsTo(x, y int) {
+	if t.cur.State&cursorOrigin != 0 {
+		y += t.top
+	}
+	t.moveTo(x, y)
+}
+
+func (t *State) moveTo(x, y int) {
+	var miny, maxy int
+	if t.cur.State&cursorOrigin != 0 {
+		miny = t.top
+		maxy = t.bottom
+	} else {
+		miny = 0
+		maxy = t.rows - 1
+	}
+	x = clamp(x, 0, t.cols-1)
+	y = clamp(y, miny, maxy)
+	t.changed |= ChangedScreen
+	t.cur.State &^= cursorWrapNext
+	t.cur.X = x
+	t.cur.Y = y
+}
+
+func (t *State) swapScreen() {
+	t.lines, t.altLines = t.altLines, t.lines
+	t.mode ^= ModeAltScreen
+	t.dirtyAll()
+}
+
+func (t *State) dirtyAll() {
+	t.changed |= ChangedScreen
+	for y := 0; y < t.rows; y++ {
+		t.dirty[y] = true
+	}
+}
+
+func (t *State) setScroll(top, bottom int) {
+	top = clamp(top, 0, t.rows-1)
+	bottom = clamp(bottom, 0, t.rows-1)
+	if top > bottom {
+		top, bottom = bottom, top
+	}
+	t.top = top
+	t.bottom = bottom
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func clamp(val, min, max int) int {
+	if val < min {
+		return min
+	} else if val > max {
+		return max
+	}
+	return val
+}
+
+func between(val, min, max int) bool {
+	if val < min || val > max {
+		return false
+	}
+	return true
+}
+
+func (t *State) scrollDown(orig, n int) {
+	n = clamp(n, 0, t.bottom-orig+1)
+	t.clear(0, t.bottom-n+1, t.cols-1, t.bottom)
+	t.changed |= ChangedScreen
+	for i := t.bottom; i >= orig+n; i-- {
+		t.lines[i], t.lines[i-n] = t.lines[i-n], t.lines[i]
+		t.dirty[i] = true
+		t.dirty[i-n] = true
+	}
+
+	// TODO: selection scroll
+}
+
+func (t *State) scrollUp(orig, n int) {
+	n = clamp(n, 0, t.bottom-orig+1)
+	t.clear(0, orig, t.cols-1, orig+n-1)
+	t.changed |= ChangedScreen
+	for i := orig; i <= t.bottom-n; i++ {
+		t.lines[i], t.lines[i+n] = t.lines[i+n], t.lines[i]
+		t.dirty[i] = true
+		t.dirty[i+n] = true
+	}
+
+	// TODO: selection scroll
+}
+
+func (t *State) modMode(set bool, bit ModeFlag) {
+	if set {
+		t.mode |= bit
+	} else {
+		t.mode &^= bit
+	}
+}
+
+func (t *State) setMode(priv bool, set bool, args []int) {
+	if priv {
+		for _, a := range args {
+			switch a {
+			case 1: // DECCKM - cursor key
+				t.modMode(set, ModeAppCursor)
+			case 5: // DECSCNM - reverse video
+				mode := t.mode
+				t.modMode(set, ModeReverse)
+				if mode != t.mode {
+					// TODO: redraw
+				}
+			case 6: // DECOM - origin
+				if set {
+					t.cur.State |= cursorOrigin
+				} else {
+					t.cur.State &^= cursorOrigin
+				}
+				t.moveAbsTo(0, 0)
+			case 7: // DECAWM - auto wrap
+				t.modMode(set, ModeWrap)
+			// IGNORED:
+			case 0, // error
+				2,  // DECANM - ANSI/VT52
+				3,  // DECCOLM - column
+				4,  // DECSCLM - scroll
+				8,  // DECARM - auto repeat
+				18, // DECPFF - printer feed
+				19, // DECPEX - printer extent
+				42, // DECNRCM - national characters
+				12: // att610 - start blinking cursor
+				break
+			case 25: // DECTCEM - text cursor enable mode
+				t.modMode(!set, ModeHide)
+			case 9: // X10 mouse compatibility mode
+				t.modMode(false, ModeMouseMask)
+				t.modMode(set, ModeMouseX10)
+			case 1000: // report button press
+				t.modMode(false, ModeMouseMask)
+				t.modMode(set, ModeMouseButton)
+			case 1002: // report motion on button press
+				t.modMode(false, ModeMouseMask)
+				t.modMode(set, ModeMouseMotion)
+			case 1003: // enable all mouse motions
+				t.modMode(false, ModeMouseMask)
+				t.modMode(set, ModeMouseMany)
+			case 1004: // send focus events to tty
+				t.modMode(set, ModeFocus)
+			case 1006: // extended reporting mode
+				t.modMode(set, ModeMouseSgr)
+			case 1034:
+				t.modMode(set, Mode8bit)
+			case 1049, // = 1047 and 1048
+				47, 1047:
+				alt := t.mode&ModeAltScreen != 0
+				if alt {
+					t.clear(0, 0, t.cols-1, t.rows-1)
+				}
+				if !set || !alt {
+					t.swapScreen()
+				}
+				if a != 1049 {
+					break
+				}
+				fallthrough
+			case 1048:
+				if set {
+					t.saveCursor()
+				} else {
+					t.restoreCursor()
+				}
+			case 1001:
+				// mouse highlight mode; can hang the terminal by design when
+				// implemented
+			case 1005:
+				// utf8 mouse mode; will confuse applications not supporting
+				// utf8 and luit
+			case 1015:
+				// urxvt mangled mouse mode; incompatiblt and can be mistaken
+				// for other control codes
+			default:
+				t.logf("unknown private set/reset mode %d\n", a)
+			}
+		}
+	} else {
+		for _, a := range args {
+			switch a {
+			case 0: // Error (ignored)
+			case 2: // KAM - keyboard action
+				t.modMode(set, ModeKeyboardLock)
+			case 4: // IRM - insertion-replacement
+				t.modMode(set, ModeInsert)
+				t.logln("insert mode not implemented")
+			case 12: // SRM - send/receive
+				t.modMode(set, ModeEcho)
+			case 20: // LNM - linefeed/newline
+				t.modMode(set, ModeCRLF)
+			case 34:
+				t.logln("right-to-left mode not implemented")
+			case 96:
+				t.logln("right-to-left copy mode not implemented")
+			default:
+				t.logf("unknown set/reset mode %d\n", a)
+			}
+		}
+	}
+}
+
+func (t *State) setAttr(attr []int) {
+	if len(attr) == 0 {
+		attr = []int{0}
+	}
+	for i := 0; i < len(attr); i++ {
+		a := attr[i]
+		switch a {
+		case 0:
+			t.cur.Attr.Mode &^= attrReverse | attrUnderline | attrBold | attrItalic | attrBlink
+			t.cur.Attr.FG = DefaultFG
+			t.cur.Attr.BG = DefaultBG
+		case 1:
+			t.cur.Attr.Mode |= attrBold
+		case 3:
+			t.cur.Attr.Mode |= attrItalic
+		case 4:
+			t.cur.Attr.Mode |= attrUnderline
+		case 5, 6: // slow, rapid blink
+			t.cur.Attr.Mode |= attrBlink
+		case 7:
+			t.cur.Attr.Mode |= attrReverse
+		case 21, 22:
+			t.cur.Attr.Mode &^= attrBold
+		case 23:
+			t.cur.Attr.Mode &^= attrItalic
+		case 24:
+			t.cur.Attr.Mode &^= attrUnderline
+		case 25, 26:
+			t.cur.Attr.Mode &^= attrBlink
+		case 27:
+			t.cur.Attr.Mode &^= attrReverse
+		case 38:
+			if i+2 < len(attr) && attr[i+1] == 5 {
+				i += 2
+				if between(attr[i], 0, 255) {
+					t.cur.Attr.FG = Color(attr[i])
+				} else {
+					t.logf("bad fgcolor %d\n", attr[i])
+				}
+			} else if i+4 < len(attr) && attr[i+1] == 2 {
+				i += 4
+				r, g, b := attr[i-2], attr[i-1], attr[i]
+				if !between(r, 0, 255) || !between(g, 0, 255) || !between(b, 0, 255) {
+					t.logf("bad fg rgb color (%d,%d,%d)\n", r, g, b)
+				} else {
+					t.cur.Attr.FG = Color(r<<16 | g<<8 | b)
+				}
+			} else {
+				t.logf("gfx attr %d unknown\n", a)
+			}
+		case 39:
+			t.cur.Attr.FG = DefaultFG
+		case 48:
+			if i+2 < len(attr) && attr[i+1] == 5 {
+				i += 2
+				if between(attr[i], 0, 255) {
+					t.cur.Attr.BG = Color(attr[i])
+				} else {
+					t.logf("bad bgcolor %d\n", attr[i])
+				}
+			} else if i+4 < len(attr) && attr[i+1] == 2 {
+				i += 4
+				r, g, b := attr[i-2], attr[i-1], attr[i]
+				if !between(r, 0, 255) || !between(g, 0, 255) || !between(b, 0, 255) {
+					t.logf("bad bg rgb color (%d,%d,%d)\n", r, g, b)
+				} else {
+					t.cur.Attr.BG = Color(r<<16 | g<<8 | b)
+				}
+			} else {
+				t.logf("gfx attr %d unknown\n", a)
+			}
+		case 49:
+			t.cur.Attr.BG = DefaultBG
+		default:
+			if between(a, 30, 37) {
+				t.cur.Attr.FG = Color(a - 30)
+			} else if between(a, 40, 47) {
+				t.cur.Attr.BG = Color(a - 40)
+			} else if between(a, 90, 97) {
+				t.cur.Attr.FG = Color(a - 90 + 8)
+			} else if between(a, 100, 107) {
+				t.cur.Attr.BG = Color(a - 100 + 8)
+			} else {
+				t.logf("gfx attr %d unknown\n", a)
+			}
+		}
+	}
+}
+
+func (t *State) insertBlanks(n int) {
+	src := t.cur.X
+	dst := src + n
+	size := t.cols - dst
+	t.changed |= ChangedScreen
+	t.dirty[t.cur.Y] = true
+
+	if dst >= t.cols {
+		t.clear(t.cur.X, t.cur.Y, t.cols-1, t.cur.Y)
+	} else {
+		copy(t.lines[t.cur.Y][dst:dst+size], t.lines[t.cur.Y][src:src+size])
+		t.clear(src, t.cur.Y, dst-1, t.cur.Y)
+	}
+}
+
+func (t *State) insertBlankLines(n int) {
+	if t.cur.Y < t.top || t.cur.Y > t.bottom {
+		return
+	}
+	t.scrollDown(t.cur.Y, n)
+}
+
+func (t *State) deleteLines(n int) {
+	if t.cur.Y < t.top || t.cur.Y > t.bottom {
+		return
+	}
+	t.scrollUp(t.cur.Y, n)
+}
+
+func (t *State) deleteChars(n int) {
+	src := t.cur.X + n
+	dst := t.cur.X
+	size := t.cols - src
+	t.changed |= ChangedScreen
+	t.dirty[t.cur.Y] = true
+
+	if src >= t.cols {
+		t.clear(t.cur.X, t.cur.Y, t.cols-1, t.cur.Y)
+	} else {
+		copy(t.lines[t.cur.Y][dst:dst+size], t.lines[t.cur.Y][src:src+size])
+		t.clear(t.cols-n, t.cur.Y, t.cols-1, t.cur.Y)
+	}
+}
+
+func (t *State) setTitle(title string) {
+	t.changed |= ChangedTitle
+	t.title = title
+}
+
+func (t *State) Size() (cols, rows int) {
+	return t.cols, t.rows
+}
+
+func (t *State) String() string {
+	t.Lock()
+	defer t.Unlock()
+
+	var view []rune
+	for y := 0; y < t.rows; y++ {
+		for x := 0; x < t.cols; x++ {
+			attr := t.Cell(x, y)
+			view = append(view, attr.Char)
+		}
+		view = append(view, '\n')
+	}
+
+	return string(view)
+}

--- a/vendor/github.com/hinshun/vt10x/str.go
+++ b/vendor/github.com/hinshun/vt10x/str.go
@@ -1,0 +1,330 @@
+package vt10x
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// STR sequences are similar to CSI sequences, but have string arguments (and
+// as far as I can tell, don't really have a name; STR is the name I took from
+// suckless which I imagine comes from rxvt or xterm).
+type strEscape struct {
+	typ  rune
+	buf  []rune
+	args []string
+}
+
+func (s *strEscape) reset() {
+	s.typ = 0
+	s.buf = s.buf[:0]
+	s.args = nil
+}
+
+func (s *strEscape) put(c rune) {
+	// TODO: improve allocs with an array backed slice; bench first
+	if len(s.buf) < 256 {
+		s.buf = append(s.buf, c)
+	}
+	// Going by st, it is better to remain silent when the STR sequence is not
+	// ended so that it is apparent to users something is wrong. The length sanity
+	// check ensures we don't absorb the entire stream into memory.
+	// TODO: see what rxvt or xterm does
+}
+
+func (s *strEscape) parse() {
+	s.args = strings.Split(string(s.buf), ";")
+}
+
+func (s *strEscape) arg(i, def int) int {
+	if i >= len(s.args) || i < 0 {
+		return def
+	}
+	i, err := strconv.Atoi(s.args[i])
+	if err != nil {
+		return def
+	}
+	return i
+}
+
+func (s *strEscape) argString(i int, def string) string {
+	if i >= len(s.args) || i < 0 {
+		return def
+	}
+	return s.args[i]
+}
+
+func (t *State) handleSTR() {
+	s := &t.str
+	s.parse()
+
+	switch s.typ {
+	case ']': // OSC - operating system command
+		var p *string
+		switch d := s.arg(0, 0); d {
+		case 0, 1, 2:
+			title := s.argString(1, "")
+			if title != "" {
+				t.setTitle(title)
+			}
+		case 10:
+			if len(s.args) < 2 {
+				break
+			}
+
+			c := s.argString(1, "")
+			p := &c
+			if p != nil && *p == "?" {
+				t.oscColorResponse(int(DefaultFG), 10)
+			} else if err := t.setColorName(int(DefaultFG), p); err != nil {
+				t.logf("invalid foreground color: %s\n", maybe(p))
+			} else {
+				// TODO: redraw
+			}
+		case 11:
+			if len(s.args) < 2 {
+				break
+			}
+
+			c := s.argString(1, "")
+			p := &c
+			if p != nil && *p == "?" {
+				t.oscColorResponse(int(DefaultBG), 11)
+			} else if err := t.setColorName(int(DefaultBG), p); err != nil {
+				t.logf("invalid cursor color: %s\n", maybe(p))
+			} else {
+				// TODO: redraw
+			}
+		// case 12:
+		// if len(s.args) < 2 {
+		// 	break
+		// }
+
+		// c := s.argString(1, "")
+		// p := &c
+		// if p != nil && *p == "?" {
+		// 	t.oscColorResponse(int(DefaultCursor), 12)
+		// } else if err := t.setColorName(int(DefaultCursor), p); err != nil {
+		// 	t.logf("invalid background color: %s\n", p)
+		// } else {
+		// 	// TODO: redraw
+		// }
+		case 4: // color set
+			if len(s.args) < 3 {
+				break
+			}
+
+			c := s.argString(2, "")
+			p = &c
+			fallthrough
+		case 104: // color reset
+			j := -1
+			if len(s.args) > 1 {
+				j = s.arg(1, 0)
+			}
+			if p != nil && *p == "?" { // report
+				t.osc4ColorResponse(j)
+			} else if err := t.setColorName(j, p); err != nil {
+				if !(d == 104 && len(s.args) <= 1) {
+					t.logf("invalid color j=%d, p=%s\n", j, maybe(p))
+				}
+			} else {
+				// TODO: redraw
+			}
+		default:
+			t.logf("unknown OSC command %d\n", d)
+			// TODO: s.dump()
+		}
+	case 'k': // old title set compatibility
+		title := s.argString(0, "")
+		if title != "" {
+			t.setTitle(title)
+		}
+	default:
+		// TODO: Ignore these codes instead of complain?
+		// 'P': // DSC - device control string
+		// '_': // APC - application program command
+		// '^': // PM - privacy message
+
+		t.logf("unhandled STR sequence '%c'\n", s.typ)
+		// t.str.dump()
+	}
+}
+
+func (t *State) setColorName(j int, p *string) error {
+	if !between(j, 0, 1<<24) {
+		return fmt.Errorf("invalid color value %d", j)
+	}
+
+	if p == nil {
+		// restore color
+		delete(t.colorOverride, Color(j))
+	} else {
+		// set color
+		r, g, b, err := parseColor(*p)
+		if err != nil {
+			return err
+		}
+		t.colorOverride[Color(j)] = Color(r<<16 | g<<8 | b)
+	}
+
+	return nil
+}
+
+func (t *State) oscColorResponse(j, num int) {
+	if j < 0 {
+		t.logf("failed to fetch osc color %d\n", j)
+		return
+	}
+
+	k, ok := t.colorOverride[Color(j)]
+	if ok {
+		j = int(k)
+	}
+
+	r, g, b := rgb(j)
+	t.w.Write([]byte(fmt.Sprintf("\033]%d;rgb:%02x%02x/%02x%02x/%02x%02x\007", num, r, r, g, g, b, b)))
+}
+
+func (t *State) osc4ColorResponse(j int) {
+	if j < 0 {
+		t.logf("failed to fetch osc4 color %d\n", j)
+		return
+	}
+
+	k, ok := t.colorOverride[Color(j)]
+	if ok {
+		j = int(k)
+	}
+
+	r, g, b := rgb(j)
+	t.w.Write([]byte(fmt.Sprintf("\033]4;%d;rgb:%02x%02x/%02x%02x/%02x%02x\007", j, r, r, g, g, b, b)))
+}
+
+func rgb(j int) (r, g, b int) {
+	return (j >> 16) & 0xff, (j >> 8) & 0xff, j & 0xff
+}
+
+var (
+	RGBPattern  = regexp.MustCompile(`^([\da-f]{1})\/([\da-f]{1})\/([\da-f]{1})$|^([\da-f]{2})\/([\da-f]{2})\/([\da-f]{2})$|^([\da-f]{3})\/([\da-f]{3})\/([\da-f]{3})$|^([\da-f]{4})\/([\da-f]{4})\/([\da-f]{4})$`)
+	HashPattern = regexp.MustCompile(`[\da-f]`)
+)
+
+func parseColor(p string) (r, g, b int, err error) {
+	if len(p) == 0 {
+		err = fmt.Errorf("empty color spec")
+		return
+	}
+
+	low := strings.ToLower(p)
+	if strings.HasPrefix(low, "rgb:") {
+		low = low[4:]
+		sm := RGBPattern.FindAllStringSubmatch(low, -1)
+		if len(sm) != 1 || len(sm[0]) == 0 {
+			err = fmt.Errorf("invalid rgb color spec: %s", p)
+			return
+		}
+		m := sm[0]
+
+		var base float64
+		if len(m[1]) > 0 {
+			base = 15
+		} else if len(m[4]) > 0 {
+			base = 255
+		} else if len(m[7]) > 0 {
+			base = 4095
+		} else {
+			base = 65535
+		}
+
+		r64, err := strconv.ParseInt(firstNonEmpty(m[1], m[4], m[7], m[10]), 16, 0)
+		if err != nil {
+			return r, g, b, err
+		}
+
+		g64, err := strconv.ParseInt(firstNonEmpty(m[2], m[5], m[8], m[11]), 16, 0)
+		if err != nil {
+			return r, g, b, err
+		}
+
+		b64, err := strconv.ParseInt(firstNonEmpty(m[3], m[6], m[9], m[12]), 16, 0)
+		if err != nil {
+			return r, g, b, err
+		}
+
+		r = int(math.Round(float64(r64) / base * 255))
+		g = int(math.Round(float64(g64) / base * 255))
+		b = int(math.Round(float64(b64) / base * 255))
+		return r, g, b, nil
+	} else if strings.HasPrefix(low, "#") {
+		low = low[1:]
+		m := HashPattern.FindAllString(low, -1)
+		if !oneOf(len(m), []int{3, 6, 9, 12}) {
+			err = fmt.Errorf("invalid hash color spec: %s", p)
+			return
+		}
+
+		adv := len(low) / 3
+		for i := 0; i < 3; i++ {
+			c, err := strconv.ParseInt(low[adv*i:adv*i+adv], 16, 0)
+			if err != nil {
+				return r, g, b, err
+			}
+
+			var v int64
+			switch adv {
+			case 1:
+				v = c << 4
+			case 2:
+				v = c
+			case 3:
+				v = c >> 4
+			default:
+				v = c >> 8
+			}
+
+			switch i {
+			case 0:
+				r = int(v)
+			case 1:
+				g = int(v)
+			case 2:
+				b = int(v)
+			}
+		}
+		return
+	} else {
+		err = fmt.Errorf("invalid color spec: %s", p)
+		return
+	}
+}
+
+func maybe(p *string) string {
+	if p == nil {
+		return "<nil>"
+	}
+	return *p
+}
+
+func firstNonEmpty(strs ...string) string {
+	if len(strs) == 0 {
+		return ""
+	}
+	for _, str := range strs {
+		if len(str) > 0 {
+			return str
+		}
+	}
+	return strs[len(strs)-1]
+}
+
+func oneOf(v int, is []int) bool {
+	for _, i := range is {
+		if v == i {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/hinshun/vt10x/vt.go
+++ b/vendor/github.com/hinshun/vt10x/vt.go
@@ -1,0 +1,89 @@
+package vt10x
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"io/ioutil"
+)
+
+// Terminal represents the virtual terminal emulator.
+type Terminal interface {
+	// View displays the virtual terminal.
+	View
+
+	// Write parses input and writes terminal changes to state.
+	io.Writer
+
+	// Parse blocks on read on pty or io.Reader, then parses sequences until
+	// buffer empties. State is locked as soon as first rune is read, and unlocked
+	// when buffer is empty.
+	Parse(bf *bufio.Reader) error
+}
+
+// View represents the view of the virtual terminal emulator.
+type View interface {
+	// String dumps the virtual terminal contents.
+	fmt.Stringer
+
+	// Size returns the size of the virtual terminal.
+	Size() (cols, rows int)
+
+	// Resize changes the size of the virtual terminal.
+	Resize(cols, rows int)
+
+	// Mode returns the current terminal mode.//
+	Mode() ModeFlag
+
+	// Title represents the title of the console window.
+	Title() string
+
+	// Cell returns the glyph containing the character code, foreground color, and
+	// background color at position (x, y) relative to the top left of the terminal.
+	Cell(x, y int) Glyph
+
+	// Cursor returns the current position of the cursor.
+	Cursor() Cursor
+
+	// CursorVisible returns the visible state of the cursor.
+	CursorVisible() bool
+
+	// Lock locks the state object's mutex.
+	Lock()
+
+	// Unlock resets change flags and unlocks the state object's mutex.
+	Unlock()
+}
+
+type TerminalOption func(*TerminalInfo)
+
+type TerminalInfo struct {
+	w          io.Writer
+	cols, rows int
+}
+
+func WithWriter(w io.Writer) TerminalOption {
+	return func(info *TerminalInfo) {
+		info.w = w
+	}
+}
+
+func WithSize(cols, rows int) TerminalOption {
+	return func(info *TerminalInfo) {
+		info.cols = cols
+		info.rows = rows
+	}
+}
+
+// New returns a new virtual terminal emulator.
+func New(opts ...TerminalOption) Terminal {
+	info := TerminalInfo{
+		w:    ioutil.Discard,
+		cols: 80,
+		rows: 24,
+	}
+	for _, opt := range opts {
+		opt(&info)
+	}
+	return newTerminal(info)
+}

--- a/vendor/github.com/hinshun/vt10x/vt_other.go
+++ b/vendor/github.com/hinshun/vt10x/vt_other.go
@@ -1,0 +1,107 @@
+// +build plan9 nacl windows
+
+package vt10x
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"unicode"
+	"unicode/utf8"
+)
+
+type terminal struct {
+	*State
+}
+
+func newTerminal(info TerminalInfo) *terminal {
+	t := &terminal{newState(info.w)}
+	t.init(info.cols, info.rows)
+	return t
+}
+
+func (t *terminal) init(cols, rows int) {
+	t.numlock = true
+	t.state = t.parse
+	t.cur.Attr.FG = DefaultFG
+	t.cur.Attr.BG = DefaultBG
+	t.Resize(cols, rows)
+	t.reset()
+}
+
+func (t *terminal) Write(p []byte) (int, error) {
+	var written int
+	r := bytes.NewReader(p)
+	t.lock()
+	defer t.unlock()
+	for {
+		c, sz, err := r.ReadRune()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return written, err
+		}
+		written += sz
+		if c == unicode.ReplacementChar && sz == 1 {
+			if r.Len() == 0 {
+				// not enough bytes for a full rune
+				return written - 1, nil
+			}
+			t.logln("invalid utf8 sequence")
+			continue
+		}
+		t.put(c)
+	}
+	return written, nil
+}
+
+// TODO: add tests for expected blocking behavior
+func (t *terminal) Parse(br *bufio.Reader) error {
+	var locked bool
+	defer func() {
+		if locked {
+			t.unlock()
+		}
+	}()
+	for {
+		c, sz, err := br.ReadRune()
+		if err != nil {
+			return err
+		}
+		if c == unicode.ReplacementChar && sz == 1 {
+			t.logln("invalid utf8 sequence")
+			break
+		}
+		if !locked {
+			t.lock()
+			locked = true
+		}
+
+		// put rune for parsing and update state
+		t.put(c)
+
+		// break if our buffer is empty, or if buffer contains an
+		// incomplete rune.
+		n := br.Buffered()
+		if n == 0 || (n < 4 && !fullRuneBuffered(br)) {
+			break
+		}
+	}
+	return nil
+}
+
+func fullRuneBuffered(br *bufio.Reader) bool {
+	n := br.Buffered()
+	buf, err := br.Peek(n)
+	if err != nil {
+		return false
+	}
+	return utf8.FullRune(buf)
+}
+
+func (t *terminal) Resize(cols, rows int) {
+	t.lock()
+	defer t.unlock()
+	_ = t.resize(cols, rows)
+}

--- a/vendor/github.com/hinshun/vt10x/vt_posix.go
+++ b/vendor/github.com/hinshun/vt10x/vt_posix.go
@@ -1,0 +1,108 @@
+// +build linux darwin dragonfly solaris openbsd netbsd freebsd
+
+package vt10x
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"unicode"
+	"unicode/utf8"
+)
+
+type terminal struct {
+	*State
+}
+
+func newTerminal(info TerminalInfo) *terminal {
+	t := &terminal{newState(info.w)}
+	t.init(info.cols, info.rows)
+	return t
+}
+
+func (t *terminal) init(cols, rows int) {
+	t.numlock = true
+	t.state = t.parse
+	t.cur.Attr.FG = DefaultFG
+	t.cur.Attr.BG = DefaultBG
+	t.Resize(cols, rows)
+	t.reset()
+}
+
+// Write parses input and writes terminal changes to state.
+func (t *terminal) Write(p []byte) (int, error) {
+	var written int
+	r := bytes.NewReader(p)
+	t.lock()
+	defer t.unlock()
+	for {
+		c, sz, err := r.ReadRune()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return written, err
+		}
+		written += sz
+		if c == unicode.ReplacementChar && sz == 1 {
+			if r.Len() == 0 {
+				// not enough bytes for a full rune
+				return written - 1, nil
+			}
+			t.logln("invalid utf8 sequence")
+			continue
+		}
+		t.put(c)
+	}
+	return written, nil
+}
+
+// TODO: add tests for expected blocking behavior
+func (t *terminal) Parse(br *bufio.Reader) error {
+	var locked bool
+	defer func() {
+		if locked {
+			t.unlock()
+		}
+	}()
+	for {
+		c, sz, err := br.ReadRune()
+		if err != nil {
+			return err
+		}
+		if c == unicode.ReplacementChar && sz == 1 {
+			t.logln("invalid utf8 sequence")
+			break
+		}
+		if !locked {
+			t.lock()
+			locked = true
+		}
+
+		// put rune for parsing and update state
+		t.put(c)
+
+		// break if our buffer is empty, or if buffer contains an
+		// incomplete rune.
+		n := br.Buffered()
+		if n == 0 || (n < 4 && !fullRuneBuffered(br)) {
+			break
+		}
+	}
+	return nil
+}
+
+func fullRuneBuffered(br *bufio.Reader) bool {
+	n := br.Buffered()
+	buf, err := br.Peek(n)
+	if err != nil {
+		return false
+	}
+	return utf8.FullRune(buf)
+}
+
+func (t *terminal) Resize(cols, rows int) {
+	t.lock()
+	defer t.unlock()
+	_ = t.resize(cols, rows)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -401,6 +401,9 @@ github.com/hashicorp/errwrap
 # github.com/hashicorp/go-multierror v1.1.1
 ## explicit; go 1.13
 github.com/hashicorp/go-multierror
+# github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02
+## explicit; go 1.14
+github.com/hinshun/vt10x
 # github.com/hpcloud/tail v1.0.0
 ## explicit
 github.com/hpcloud/tail
@@ -473,7 +476,6 @@ github.com/modern-go/reflect2
 github.com/navidys/tvxwidgets
 # github.com/navidys/vtterm v0.1.0
 ## explicit; go 1.17
-github.com/navidys/vtterm
 # github.com/opencontainers/go-digest v1.0.0
 ## explicit; go 1.13
 github.com/opencontainers/go-digest


### PR DESCRIPTION
Using vt10x package instead of vtterm that will allow automatic terminal resize.
Updating container exec dialog and removing detach keys input field. By selecting "close" button it will automatically detach if exec is in attached mode.
Using "containers/podman/pkg/channel" instead of utils/streams. pkg/channel was also previsouly used in image build dialog.

Signed-off-by: Navid Yaghoobi <n.yaghoobi.s@gmail.com>