### PR TITLE
image history dialog ui update

### DIFF
--- a/ui/images/imgdialogs/history.go
+++ b/ui/images/imgdialogs/history.go
@@ -38,9 +38,13 @@ func NewImageHistoryDialog() *ImageHistoryDialog {
 	}
 
 	bgColor := utils.Styles.ImageHistoryDialog.BgColor
+	historyTableBgColor := utils.Styles.ImageHistoryDialog.ResultTableBgColor
+	historyTableBorderColor := utils.Styles.ImageHistoryDialog.ResultTableBorderColor
 
 	dialog.table = tview.NewTable()
-	dialog.table.SetBackgroundColor(bgColor)
+	dialog.table.SetBorder(true)
+	dialog.table.SetBorderColor(historyTableBorderColor)
+	dialog.table.SetBackgroundColor(historyTableBgColor)
 	dialog.initTable()
 
 	dialog.form = tview.NewForm().
@@ -156,15 +160,15 @@ func (d *ImageHistoryDialog) SetCancelFunc(handler func()) *ImageHistoryDialog {
 }
 
 func (d *ImageHistoryDialog) initTable() {
-	bgColor := utils.Styles.ImageHistoryDialog.HeaderRow.BgColor
-	fgColor := utils.Styles.ImageHistoryDialog.HeaderRow.FgColor
+	bgColor := utils.Styles.ImageHistoryDialog.ResultHeaderRow.BgColor
+	fgColor := utils.Styles.ImageHistoryDialog.ResultHeaderRow.FgColor
 
 	d.table.Clear()
 	d.table.SetFixed(1, 1)
 	d.table.SetSelectable(true, false)
 	for i := 0; i < len(d.tableHeaders); i++ {
 		d.table.SetCell(0, i,
-			tview.NewTableCell(fmt.Sprintf("[%s::]%s", utils.GetColorName(fgColor), strings.ToUpper(d.tableHeaders[i]))).
+			tview.NewTableCell(fmt.Sprintf("[%s::b]%s", utils.GetColorName(fgColor), strings.ToUpper(d.tableHeaders[i]))).
 				SetExpansion(0).
 				SetBackgroundColor(bgColor).
 				SetTextColor(fgColor).

--- a/ui/utils/style.go
+++ b/ui/utils/style.go
@@ -73,11 +73,13 @@ var Styles = theme{
 		},
 	},
 	ImageHistoryDialog: imageHistoryDialog{
-		BgColor: tcell.ColorSteelBlue,
-		FgColor: tcell.ColorBlack,
-		HeaderRow: headerRow{
+		BgColor:                tcell.ColorSteelBlue,
+		FgColor:                tcell.ColorBlack,
+		ResultTableBgColor:     tview.Styles.PrimitiveBackgroundColor,
+		ResultTableBorderColor: tcell.ColorWhite,
+		ResultHeaderRow: headerRow{
 			FgColor: tcell.ColorWhite,
-			BgColor: tcell.ColorNavy,
+			BgColor: tcell.ColorSteelBlue,
 		},
 	},
 	ImageImportDialog: imageImportDialog{

--- a/ui/utils/style_windows.go
+++ b/ui/utils/style_windows.go
@@ -73,9 +73,11 @@ var Styles = theme{
 		},
 	},
 	ImageHistoryDialog: imageHistoryDialog{
-		BgColor: tcell.ColorPink,
-		FgColor: tcell.ColorWhite,
-		HeaderRow: headerRow{
+		BgColor:                tcell.ColorPink,
+		FgColor:                tcell.ColorWhite,
+		ResultTableBgColor:     tview.Styles.PrimitiveBackgroundColor,
+		ResultTableBorderColor: tview.Styles.PrimaryTextColor,
+		ResultHeaderRow: headerRow{
 			FgColor: tcell.ColorWhite,
 			BgColor: tcell.ColorPurple,
 		},

--- a/ui/utils/theme.go
+++ b/ui/utils/theme.go
@@ -107,9 +107,11 @@ type imageSearchDialog struct {
 }
 
 type imageHistoryDialog struct {
-	BgColor   tcell.Color
-	FgColor   tcell.Color
-	HeaderRow headerRow
+	BgColor                tcell.Color
+	FgColor                tcell.Color
+	ResultHeaderRow        headerRow
+	ResultTableBgColor     tcell.Color
+	ResultTableBorderColor tcell.Color
 }
 
 type imageImportDialog struct {


### PR DESCRIPTION
Image history UI dialog update in order to be consistent with other dialogs and make it easier to read the history result

**New style:**
![Screenshot from 2022-05-08 18-09-33](https://user-images.githubusercontent.com/5696685/167287581-c5db7527-4c63-4ac0-ac5f-b9e93e949fbd.png)

**Previous style:**
![Screenshot from 2022-05-08 18-10-00](https://user-images.githubusercontent.com/5696685/167287583-54b3b833-1dff-4b96-a1e2-37225a570949.png)

Signed-off-by: Navid Yaghoobi <n.yaghoobi.s@gmail.com>