### PR TITLE
bump v0.4.0

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	appVersion = "0.4.0"
+	appVersion = "0.5.0-dev"
 )
 
 // versionCmd represents the version command

--- a/podman-tui.spec.rpkg
+++ b/podman-tui.spec.rpkg
@@ -15,8 +15,8 @@
 %global git0 https://%{import_path}
 
 Name: podman-tui
-Version: 0.4.0
-Release: 1%{?dist}
+Version: 0.5.0
+Release: dev.1%{?dist}
 Summary: Podman Terminal User Interface
 License: ASL 2.0
 URL: %{git0}
@@ -66,6 +66,8 @@ install -p ./bin/%{name} %{buildroot}%{_bindir}
 %{_bindir}/%{name}
 
 %changelog
+* Thu Jun 02 2022 Navid Yaghoobi <n.yaghoobi.s@gmail.com> 0.5.0-dev-1
+
 * Thu Jun 02 2022 Navid Yaghoobi <n.yaghoobi.s@gmail.com> 0.4.0-1
 - new ui color theme
 - CI setup


### PR DESCRIPTION
- new ui color theme
- CI setup
- update vagrant box to Fedora 36
- pre-commit configuration and fixes
- exec terminal update (automatic resize and detach)
- adding image tree command
- adding security options fields to pod create dialog
- adding container create security options fields
- adding format and security options fields to image build dialog
- doc update
- windows support
- removing unused connection dialog
- fixing golint
- removing image index from name field string search result
- pod/container top dialog ui update
- image history dialog ui update
- container stats dialog ui update
- image search/pull dialog ui update
- sort categories for pod/containers create and image build dialogs
- code coverage for ui/dialogs package
- Bump github.com/docker/docker
- Bump github.com/containers/storage from 1.40.2 to 1.41.0
- Bump github.com/containers/podman/v4 from 4.0.3 to 4.1.0
- Bump github.com/containers/buildah from 1.25.1 to 1.26.1
- Bump github.com/containers/common from 0.47.5 to 0.48.0
- Bump github.com/containers/storage from 1.40.0 to 1.40.2
- Bump github.com/containers/storage from 1.39.0 to 1.40.0