### PR TITLE
image history dialog update

### DIFF
--- a/ui/images/imgdialogs/history.go
+++ b/ui/images/imgdialogs/history.go
@@ -118,7 +118,7 @@ func (d *ImageHistoryDialog) InputHandler() func(event *tcell.EventKey, setFocus
 func (d *ImageHistoryDialog) SetRect(x, y, width, height int) {
 	dX := x + dialogs.DialogPadding
 	dWidth := width - (2 * dialogs.DialogPadding)
-	dHeight := len(d.results) + dialogs.DialogFormHeight + 3
+	dHeight := len(d.results) + dialogs.DialogFormHeight + 5
 
 	if dHeight > height {
 		dHeight = height
@@ -169,7 +169,7 @@ func (d *ImageHistoryDialog) initTable() {
 	for i := 0; i < len(d.tableHeaders); i++ {
 		d.table.SetCell(0, i,
 			tview.NewTableCell(fmt.Sprintf("[%s::b]%s", utils.GetColorName(fgColor), strings.ToUpper(d.tableHeaders[i]))).
-				SetExpansion(0).
+				SetExpansion(1).
 				SetBackgroundColor(bgColor).
 				SetTextColor(fgColor).
 				SetAlign(tview.AlignLeft).


### PR DESCRIPTION
1. Image history dialog height was causing the first two rows not to be displayed.
2. Expand image history table headers.

**Before**:
![image_history_01](https://user-images.githubusercontent.com/5696685/171930241-067e7d37-397f-461c-8a42-7642e4003455.jpeg)

**After**:
![image_history_02](https://user-images.githubusercontent.com/5696685/171930268-92b6e490-75ba-4282-a406-441016036381.jpeg)


Signed-off-by: Navid Yaghoobi <n.yaghoobi.s@gmail.com>