### PR TITLE
new feature - container commit

### DIFF
--- a/pdcs/containers/commit.go
+++ b/pdcs/containers/commit.go
@@ -1,0 +1,44 @@
+package containers
+
+import (
+	"strings"
+
+	"github.com/containers/podman-tui/pdcs/registry"
+	"github.com/containers/podman/v4/pkg/bindings/containers"
+	"github.com/rs/zerolog/log"
+)
+
+type CntCommitOptions struct {
+	Author  string
+	Changes []string
+	Message string
+	Format  string
+	Pause   bool
+	Squash  bool
+	Image   string
+}
+
+// Commit creates an image from a container's changes
+func Commit(id string, opts CntCommitOptions) (string, error) {
+	log.Debug().Msgf("pdcs: podman container commit %s", id)
+	conn, err := registry.GetConnection()
+	if err != nil {
+		return "", err
+	}
+
+	commitOpts := new(containers.CommitOptions)
+	commitOpts.WithAuthor(opts.Author)
+	commitOpts.WithChanges(opts.Changes)
+	commitOpts.WithComment(opts.Message)
+	commitOpts.WithPause(opts.Pause)
+	commitOpts.WithSquash(opts.Squash)
+
+	imageRepoTag := strings.Split(opts.Image, ":")
+	commitOpts.WithRepo(imageRepoTag[0])
+	if len(imageRepoTag) > 1 {
+		commitOpts.WithTag(imageRepoTag[1])
+	}
+
+	response, err := containers.Commit(conn, id, commitOpts)
+	return response.ID, err
+}

--- a/test/005-container.bats
+++ b/test/005-container.bats
@@ -105,6 +105,26 @@ load helpers_tui
 
 }
 
+@test "container commit" {
+    container_index=$(podman container ls --all --format "{{ .Names }}" | sort | nl -v 0 | grep "$TEST_CONTAINER_NAME" | awk '{print $1}')
+
+    # switch to containers view
+    # select container from the list
+    # select commit command from container commands dialog
+    # fillout image input field
+    # go to commit button and press enter
+    podman_tui_set_view "containers"
+    podman_tui_select_item $container_index
+    podman_tui_select_container_cmd "commit"
+
+    podman_tui_send_inputs $TEST_CONTAINER_COMMIT_IMAGE_NAME
+    podman_tui_send_inputs Tab Tab Tab Tab Tab Tab Tab
+    podman_tui_send_inputs Tab Enter
+    sleep 2
+    run_helper podman image ls ${TEST_CONTAINER_COMMIT_IMAGE_NAME} --format "{{ .Repository }}"
+    assert "$output" =~ "localhost/${TEST_CONTAINER_COMMIT_IMAGE_NAME}" "expected image"
+}
+
 @test "container start" {
     container_index=$(podman container ls --all --format "{{ .Names }}" | sort | nl -v 0 | grep "$TEST_CONTAINER_NAME" | awk '{print $1}')
 

--- a/test/helpers_tui.bash
+++ b/test/helpers_tui.bash
@@ -10,6 +10,7 @@ TEST_CONTAINER_NAME="${TEST_NAME}_container01"
 TEST_CONTAINER_POD_NAME="${TEST_NAME}_container01_pod"
 TEST_CONTAINER_NETWORK_NAME="${TEST_NAME}_container01_net"
 TEST_CONTAINER_VOLUME_NAME="${TEST_NAME}_container01_vol"
+TEST_CONTAINER_COMMIT_IMAGE_NAME="${TEST_NAME}_commited_image"
 TEST_CONTAINER_PORT="8888:80"
 TEST_LABEL_NAME="test"
 TEST_LABEL_VALUE="$TEST_NAME"
@@ -182,37 +183,39 @@ function podman_tui_select_container_cmd() {
   local menu_index=0
 
   case $1 in
-  "create")
+  "commit")
     menu_index=0;;
-  "diff")
+  "create")
     menu_index=1;;
-  "exec")
+  "diff")
     menu_index=2;;
-  "inspect")
+  "exec")
     menu_index=3;;
-  "kill")
+  "inspect")
     menu_index=4;;
-  "logs")
+  "kill")
     menu_index=5;;
-  "pause")
+  "logs")
     menu_index=6;;
-  "port")
+  "pause")
     menu_index=7;;
-  "prune")
+  "port")
     menu_index=8;;
-  "rename")
+  "prune")
     menu_index=9;;
-  "remove")
+  "rename")
     menu_index=10;;
-  "start")
+  "remove")
     menu_index=11;;
-  # index 12 stats
+  "start")
+    menu_index=12;;
+  # index 13 stats
   "stop")
-    menu_index=13;;
-  "top")
     menu_index=14;;
-  "unpause")
+  "top")
     menu_index=15;;
+  "unpause")
+    menu_index=16;;
   esac
 
   podman_tui_select_menu $menu_index

--- a/ui/containers/cntdialogs/cntdialogs_suite_test.go
+++ b/ui/containers/cntdialogs/cntdialogs_suite_test.go
@@ -1,0 +1,13 @@
+package cntdialogs_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCntdialogs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Containers Dialogs Suite")
+}

--- a/ui/containers/cntdialogs/commit.go
+++ b/ui/containers/cntdialogs/commit.go
@@ -1,0 +1,419 @@
+package cntdialogs
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/containers/buildah/define"
+	"github.com/containers/podman-tui/pdcs/containers"
+	"github.com/containers/podman-tui/ui/dialogs"
+	"github.com/containers/podman-tui/ui/utils"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	cntCommitDialogMaxWidth  = 90
+	cntCommitDialogMaxHeight = 15
+)
+
+const (
+	cntCommitImageFocus = 0 + iota
+	cntCommitAuthorFocus
+	cntCommitChangeFocus
+	cntCommitFormatFocus
+	cntCommitMessageFocus
+	cntCommitPauseFocus
+	cntCommitSquashFocus
+	cntCommitFormFocus
+)
+
+// ContainerCommitDialog represents container commit dialog primitive
+type ContainerCommitDialog struct {
+	*tview.Box
+	layout        *tview.Flex
+	cntInfo       *tview.TextView
+	image         *tview.InputField
+	author        *tview.InputField
+	change        *tview.InputField
+	format        *tview.DropDown
+	message       *tview.InputField
+	pause         *tview.Checkbox
+	squash        *tview.Checkbox
+	form          *tview.Form
+	display       bool
+	commitHandler func()
+	cancelHandler func()
+	focusElement  int
+}
+
+// NewContainerCommitDialog returns new container commit dialog primitive
+func NewContainerCommitDialog() *ContainerCommitDialog {
+	dialog := &ContainerCommitDialog{
+		Box:     tview.NewBox(),
+		cntInfo: tview.NewTextView(),
+		layout:  tview.NewFlex(),
+		image:   tview.NewInputField(),
+		author:  tview.NewInputField(),
+		change:  tview.NewInputField(),
+		format:  tview.NewDropDown(),
+		message: tview.NewInputField(),
+		pause:   tview.NewCheckbox(),
+		squash:  tview.NewCheckbox(),
+		form:    tview.NewForm(),
+	}
+
+	bgColor := utils.Styles.ContainerCommitDialog.BgColor
+	fgColor := utils.Styles.ContainerCommitDialog.FgColor
+	inputFieldBgColor := utils.Styles.InputFieldPrimitive.BgColor
+	ddUnselectedStyle := utils.Styles.DropdownStyle.Unselected
+	ddselectedStyle := utils.Styles.DropdownStyle.Selected
+	labelWidth := 9
+
+	// container info text view
+	dialog.cntInfo.SetBackgroundColor(bgColor)
+	dialog.cntInfo.SetTextColor(fgColor)
+	dialog.cntInfo.SetDynamicColors(true)
+
+	// image field
+	dialog.image.SetBackgroundColor(bgColor)
+	dialog.image.SetLabelColor(fgColor)
+	dialog.image.SetLabel("Image:")
+	dialog.image.SetLabelWidth(labelWidth)
+	dialog.image.SetFieldBackgroundColor(inputFieldBgColor)
+
+	// author field
+	authorLabel := "Author:"
+	dialog.author.SetBackgroundColor(bgColor)
+	dialog.author.SetLabelColor(fgColor)
+	dialog.author.SetLabel(authorLabel)
+	dialog.author.SetLabelWidth(len(authorLabel) + 1)
+	dialog.author.SetFieldBackgroundColor(inputFieldBgColor)
+
+	// change field
+	dialog.change.SetBackgroundColor(bgColor)
+	dialog.change.SetLabelColor(fgColor)
+	dialog.change.SetLabel("Change:")
+	dialog.change.SetLabelWidth(labelWidth)
+	dialog.change.SetFieldBackgroundColor(inputFieldBgColor)
+
+	// format options dropdown
+	dialog.format.SetLabel("Format:")
+	dialog.format.SetTitleAlign(tview.AlignRight)
+	dialog.format.SetLabelColor(fgColor)
+	dialog.format.SetLabelWidth(labelWidth)
+	dialog.format.SetBackgroundColor(bgColor)
+	dialog.format.SetOptions([]string{
+		define.OCI,
+		define.DOCKER},
+		nil)
+	dialog.format.SetListStyles(ddUnselectedStyle, ddselectedStyle)
+	dialog.format.SetFieldBackgroundColor(inputFieldBgColor)
+
+	// commit message field
+	dialog.message.SetBackgroundColor(bgColor)
+	dialog.message.SetLabelColor(fgColor)
+	dialog.message.SetLabel("Message:")
+	dialog.message.SetLabelWidth(labelWidth)
+	dialog.message.SetFieldBackgroundColor(inputFieldBgColor)
+
+	// pause checkbox
+	pauseLabel := "Pause container:"
+	dialog.pause.SetBackgroundColor(bgColor)
+	dialog.pause.SetLabelColor(fgColor)
+	dialog.pause.SetLabel(pauseLabel)
+	dialog.pause.SetLabelWidth(len(pauseLabel) + 1)
+	dialog.pause.SetFieldBackgroundColor(inputFieldBgColor)
+
+	// squash checkbox
+	squashLabel := "Squash layers:"
+	dialog.squash.SetBackgroundColor(bgColor)
+	dialog.squash.SetLabelColor(fgColor)
+	dialog.squash.SetLabel(squashLabel)
+	dialog.squash.SetLabelWidth(len(squashLabel) + 1)
+	dialog.squash.SetFieldBackgroundColor(inputFieldBgColor)
+
+	// form
+	dialog.form.AddButton("Cancel", nil)
+	dialog.form.AddButton("Commit", nil)
+	dialog.form.SetButtonsAlign(tview.AlignRight)
+	dialog.form.SetBackgroundColor(bgColor)
+	dialog.form.SetButtonBackgroundColor(utils.Styles.ButtonPrimitive.BgColor)
+
+	// image and author layout row
+	iaLayout := tview.NewFlex().SetDirection(tview.FlexColumn)
+	iaLayout.SetBackgroundColor(bgColor)
+	iaLayout.AddItem(dialog.image, 0, 1, true)
+	iaLayout.AddItem(utils.EmptyBoxSpace(bgColor), 2, 0, false)
+	iaLayout.AddItem(dialog.author, 0, 1, true)
+
+	// dropdown and checkbox layout row
+	dcLayout := tview.NewFlex().SetDirection(tview.FlexColumn)
+	dcLayout.SetBackgroundColor(bgColor)
+	dcLayout.AddItem(dialog.format, 0, 1, true)
+	dcLayout.AddItem(dialog.squash, 0, 1, true)
+	dcLayout.AddItem(dialog.pause, 0, 1, true)
+	dcLayout.AddItem(utils.EmptyBoxSpace(bgColor), 0, 1, false)
+
+	// inputs layout
+	layout := tview.NewFlex().SetDirection(tview.FlexRow)
+	layout.AddItem(utils.EmptyBoxSpace(bgColor), 0, 1, false)
+	layout.AddItem(dialog.cntInfo, 0, 1, true)
+	layout.AddItem(utils.EmptyBoxSpace(bgColor), 0, 1, false)
+	layout.AddItem(iaLayout, 0, 1, true)
+	layout.AddItem(utils.EmptyBoxSpace(bgColor), 0, 1, false)
+	layout.AddItem(dialog.change, 0, 1, true)
+	layout.AddItem(utils.EmptyBoxSpace(bgColor), 0, 1, false)
+	layout.AddItem(dcLayout, 0, 1, true)
+	layout.AddItem(utils.EmptyBoxSpace(bgColor), 0, 1, false)
+	layout.AddItem(dialog.message, 0, 1, true)
+
+	inputLayout := tview.NewFlex().SetDirection(tview.FlexColumn)
+	inputLayout.SetBackgroundColor(bgColor)
+	inputLayout.AddItem(utils.EmptyBoxSpace(bgColor), 1, 0, false)
+	inputLayout.AddItem(layout, 0, 1, true)
+	inputLayout.AddItem(utils.EmptyBoxSpace(bgColor), 1, 0, false)
+
+	// main layout
+	dialog.layout.SetDirection(tview.FlexRow)
+	dialog.layout.SetBackgroundColor(bgColor)
+	dialog.layout.SetBorder(true)
+	dialog.layout.SetTitle("PODMAN CONTAINER COMMIT")
+	dialog.layout.AddItem(inputLayout, 0, 1, true)
+	dialog.layout.AddItem(dialog.form, dialogs.DialogFormHeight, 0, true)
+
+	dialog.Hide()
+	return dialog
+}
+
+// Display displays this primitive
+func (d *ContainerCommitDialog) Display() {
+	d.display = true
+}
+
+// IsDisplay returns true if primitive is shown
+func (d *ContainerCommitDialog) IsDisplay() bool {
+	return d.display
+}
+
+// Hide stops displaying this primitive
+func (d *ContainerCommitDialog) Hide() {
+	d.display = false
+	d.focusElement = cntCommitImageFocus
+	d.image.SetText("")
+	d.author.SetText("")
+	d.change.SetText("")
+	d.format.SetCurrentOption(0)
+	d.message.SetText("")
+	d.pause.SetChecked(false)
+	d.squash.SetChecked(false)
+	d.SetContainerInfo("", "")
+}
+
+// HasFocus returns whether or not this primitive has focus
+func (d *ContainerCommitDialog) HasFocus() bool {
+	if d.image.HasFocus() || d.author.HasFocus() {
+		return true
+	}
+	if d.change.HasFocus() || d.format.HasFocus() {
+		return true
+	}
+	if d.pause.HasFocus() || d.squash.HasFocus() {
+		return true
+	}
+	if d.message.HasFocus() || d.form.HasFocus() {
+		return true
+	}
+	if d.layout.HasFocus() || d.Box.HasFocus() {
+		return true
+	}
+	return false
+}
+
+// Focus is called when this primitive receives focus
+func (d *ContainerCommitDialog) Focus(delegate func(p tview.Primitive)) {
+	switch d.focusElement {
+	case cntCommitImageFocus:
+		delegate(d.image)
+	case cntCommitAuthorFocus:
+		delegate(d.author)
+	case cntCommitChangeFocus:
+		delegate(d.change)
+	case cntCommitFormatFocus:
+		delegate(d.format)
+	case cntCommitMessageFocus:
+		delegate(d.message)
+	case cntCommitPauseFocus:
+		delegate(d.pause)
+	case cntCommitSquashFocus:
+		delegate(d.squash)
+	case cntCommitFormFocus:
+		button := d.form.GetButton(d.form.GetButtonCount() - 1)
+		button.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+			if event.Key() == utils.SwitchFocusKey.Key {
+				d.focusElement = cntCommitImageFocus
+				d.Focus(delegate)
+				d.form.SetFocus(0)
+				return nil
+			}
+			return event
+		})
+		delegate(d.form)
+	}
+}
+
+// InputHandler returns input handler function for this primitive
+func (d *ContainerCommitDialog) InputHandler() func(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
+	return d.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
+		log.Debug().Msgf("container commit dialog: event %v received", event)
+		if event.Key() == utils.SwitchFocusKey.Key {
+			d.setFocusElement()
+		}
+		// dropdown widgets shall handle events before "Esc" key handler
+		if d.format.HasFocus() {
+			event = utils.ParseKeyEventKey(event)
+			if formatHandler := d.format.InputHandler(); formatHandler != nil {
+				formatHandler(event, setFocus)
+				return
+			}
+		}
+		if event.Key() == tcell.KeyEsc {
+			d.cancelHandler()
+			return
+		}
+		if d.image.HasFocus() {
+			if imageHandler := d.image.InputHandler(); imageHandler != nil {
+				imageHandler(event, setFocus)
+				return
+			}
+		}
+		if d.author.HasFocus() {
+			if authorHandler := d.author.InputHandler(); authorHandler != nil {
+				authorHandler(event, setFocus)
+				return
+			}
+		}
+		if d.change.HasFocus() {
+			if changeHandler := d.change.InputHandler(); changeHandler != nil {
+				changeHandler(event, setFocus)
+				return
+			}
+		}
+		if d.message.HasFocus() {
+			if messageHandler := d.message.InputHandler(); messageHandler != nil {
+				messageHandler(event, setFocus)
+				return
+			}
+		}
+		if d.pause.HasFocus() {
+			if pauseHandler := d.pause.InputHandler(); pauseHandler != nil {
+				pauseHandler(event, setFocus)
+				return
+			}
+		}
+		if d.squash.HasFocus() {
+			if squashHandler := d.squash.InputHandler(); squashHandler != nil {
+				squashHandler(event, setFocus)
+				return
+			}
+		}
+		if d.form.HasFocus() {
+			if formHandler := d.form.InputHandler(); formHandler != nil {
+				formHandler(event, setFocus)
+				return
+			}
+		}
+	})
+}
+
+func (d *ContainerCommitDialog) setFocusElement() {
+	switch d.focusElement {
+	case cntCommitImageFocus:
+		d.focusElement = cntCommitAuthorFocus
+	case cntCommitAuthorFocus:
+		d.focusElement = cntCommitChangeFocus
+	case cntCommitChangeFocus:
+		d.focusElement = cntCommitFormatFocus
+	case cntCommitFormatFocus:
+		d.focusElement = cntCommitSquashFocus
+	case cntCommitSquashFocus:
+		d.focusElement = cntCommitPauseFocus
+	case cntCommitPauseFocus:
+		d.focusElement = cntCommitMessageFocus
+	case cntCommitMessageFocus:
+		d.focusElement = cntCommitFormFocus
+	}
+}
+
+// SetRect set rects for this primitive.
+func (d *ContainerCommitDialog) SetRect(x, y, width, height int) {
+
+	if width > cntCommitDialogMaxWidth {
+		emptySpace := (width - cntCommitDialogMaxWidth) / 2
+		x = x + emptySpace
+		width = cntCommitDialogMaxWidth
+	}
+
+	if height > cntCommitDialogMaxHeight {
+		emptySpace := (height - cntCommitDialogMaxHeight) / 2
+		y = y + emptySpace
+		height = cntCommitDialogMaxHeight
+	}
+
+	d.Box.SetRect(x, y, width, height)
+}
+
+// Draw draws this primitive onto the screen.
+func (d *ContainerCommitDialog) Draw(screen tcell.Screen) {
+	if !d.display {
+		return
+	}
+	d.Box.DrawForSubclass(screen, d)
+	x, y, width, height := d.Box.GetInnerRect()
+	d.layout.SetRect(x, y, width, height)
+	d.layout.Draw(screen)
+}
+
+// SetCommitFunc sets form commit button selected function
+func (d *ContainerCommitDialog) SetCommitFunc(handler func()) *ContainerCommitDialog {
+	d.commitHandler = handler
+	commitButton := d.form.GetButton(d.form.GetButtonCount() - 1)
+	commitButton.SetSelectedFunc(handler)
+	return d
+}
+
+// SetCancelFunc sets form cancel button selected function
+func (d *ContainerCommitDialog) SetCancelFunc(handler func()) *ContainerCommitDialog {
+	d.cancelHandler = handler
+	cancelButton := d.form.GetButton(d.form.GetButtonCount() - 2)
+	cancelButton.SetSelectedFunc(handler)
+	return d
+}
+
+// SetImageInfo sets selected container ID and name in commit dialog
+func (d *ContainerCommitDialog) SetContainerInfo(id string, name string) {
+	containerInfo := fmt.Sprintf("Container: %s (%s)", id, name)
+	d.cntInfo.SetText(containerInfo)
+}
+
+// GetContainerCommitOptions returns container commit options based on user inputs
+func (d *ContainerCommitDialog) GetContainerCommitOptions() containers.CntCommitOptions {
+	var opts containers.CntCommitOptions
+
+	opts.Image = strings.TrimSpace(d.image.GetText())
+	opts.Author = strings.TrimSpace(d.author.GetText())
+	opts.Changes = strings.Split(d.change.GetText(), " ")
+	_, format := d.format.GetCurrentOption()
+	switch format {
+	case "oci":
+		opts.Format = define.OCIv1ImageManifest
+	case "docker":
+		opts.Format = define.Dockerv2ImageManifest
+	}
+	opts.Pause = d.pause.IsChecked()
+	opts.Squash = d.squash.IsChecked()
+	opts.Message = strings.TrimSpace(d.message.GetText())
+
+	return opts
+}

--- a/ui/containers/cntdialogs/commit_test.go
+++ b/ui/containers/cntdialogs/commit_test.go
@@ -1,0 +1,196 @@
+package cntdialogs
+
+import (
+	"fmt"
+
+	"github.com/containers/buildah/define"
+	"github.com/gdamore/tcell/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rivo/tview"
+	"github.com/rs/zerolog"
+)
+
+var _ = Describe("container commit", Ordered, func() {
+	var app *tview.Application
+	var screen tcell.SimulationScreen
+	var commitDialog *ContainerCommitDialog
+	var runApp func()
+
+	BeforeAll(func() {
+		app = tview.NewApplication()
+		commitDialog = NewContainerCommitDialog()
+		screen = tcell.NewSimulationScreen("UTF-8")
+		err := screen.Init()
+		if err != nil {
+			panic(err)
+		}
+		runApp = func() {
+			if err := app.SetScreen(screen).SetRoot(commitDialog, true).Run(); err != nil {
+				panic(err)
+			}
+		}
+		zerolog.SetGlobalLevel(zerolog.Disabled)
+		go runApp()
+	})
+
+	It("display", func() {
+		commitDialog.Display()
+		Expect(commitDialog.IsDisplay()).To(Equal(true))
+	})
+
+	It("set focus", func() {
+		app.SetFocus(commitDialog)
+		Expect(commitDialog.HasFocus()).To(Equal(true))
+	})
+
+	It("set container info", func() {
+		cntID := "cntID"
+		cntName := "cntName"
+		cntInfoWants := fmt.Sprintf("Container: %s (%s)", cntID, cntName)
+		commitDialog.SetContainerInfo(cntID, cntName)
+		Expect(commitDialog.cntInfo.GetText(true)).To(Equal(cntInfoWants))
+	})
+
+	It("cancel button selected", func() {
+		cancelFunc := func() {
+			commitDialog.Hide()
+		}
+		commitDialog.Hide()
+		app.Draw()
+		commitDialog.SetCancelFunc(cancelFunc)
+		commitDialog.Display()
+		app.Draw()
+		app.SetFocus(commitDialog.form)
+		app.QueueEvent(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
+		app.Draw()
+		Expect(commitDialog.IsDisplay()).To(Equal(false))
+	})
+
+	It("commit button selected", func() {
+		commitButton := "initial"
+		commitButtonWants := "commit selected"
+		commitFunc := func() {
+			commitButton = commitButtonWants
+		}
+		commitDialog.Hide()
+		app.Draw()
+		commitDialog.SetCommitFunc(commitFunc)
+		commitDialog.Display()
+		app.Draw()
+		app.SetFocus(commitDialog.form)
+		app.QueueEvent(tcell.NewEventKey(tcell.KeyTab, 0, tcell.ModNone))
+		app.QueueEvent(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
+		app.Draw()
+		Expect(commitButton).To(Equal(commitButtonWants))
+	})
+
+	It("set commit handler", func() {
+		commit := "initial"
+		commitWants := "commit"
+		commitHandler := func() {
+			commit = commitWants
+		}
+		commitDialog.SetCommitFunc(commitHandler)
+		commitDialog.commitHandler()
+		Expect(commit).To(Equal(commitWants))
+	})
+
+	It("set cancel handler", func() {
+		cancel := "initial"
+		cancelWants := "cancel"
+		cancelHandler := func() {
+			cancel = cancelWants
+		}
+		commitDialog.SetCancelFunc(cancelHandler)
+		commitDialog.cancelHandler()
+		Expect(cancel).To(Equal(cancelWants))
+	})
+
+	It("get commit options", func() {
+		opts := struct {
+			Image   string
+			Author  string
+			Change  []string
+			Format  string
+			Squash  bool
+			Pause   bool
+			Message string
+		}{
+			Image:   "a",                // (256,97,0)
+			Author:  "b",                // (256,98,0)
+			Change:  []string{"c", "d"}, // (256,99,0) (256,100,0)
+			Format:  define.Dockerv2ImageManifest,
+			Squash:  true,
+			Pause:   true,
+			Message: "e", // (256,101,0)
+		}
+
+		commitDialog.Hide()
+		app.Draw()
+		commitDialog.Display()
+		app.SetFocus(commitDialog)
+		app.Draw()
+		// image input field
+		app.QueueEvent(tcell.NewEventKey(256, 97, tcell.ModNone))
+		app.Draw()
+		// author input field
+		commitDialog.setFocusElement()
+		app.SetFocus(commitDialog)
+		app.Draw()
+		app.QueueEvent(tcell.NewEventKey(256, 98, tcell.ModNone))
+		app.Draw()
+		// change input field
+		commitDialog.setFocusElement()
+		app.SetFocus(commitDialog)
+		app.Draw()
+		app.QueueEvent(tcell.NewEventKey(256, 99, tcell.ModNone))
+		app.QueueEvent(tcell.NewEventKey(256, 32, tcell.ModNone)) // space
+		app.QueueEvent(tcell.NewEventKey(256, 100, tcell.ModNone))
+		app.Draw()
+		// format dropdown
+		commitDialog.setFocusElement()
+		app.SetFocus(commitDialog)
+		app.Draw()
+		app.QueueEvent(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
+		app.QueueEvent(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone))
+		app.QueueEvent(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
+		app.Draw()
+		// squash checkbox
+		commitDialog.setFocusElement()
+		app.SetFocus(commitDialog)
+		app.Draw()
+		app.QueueEvent(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
+		app.Draw()
+		// pause checkbox
+		commitDialog.setFocusElement()
+		app.SetFocus(commitDialog)
+		app.Draw()
+		app.QueueEvent(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
+		app.Draw()
+		// message input field
+		commitDialog.setFocusElement()
+		app.SetFocus(commitDialog)
+		app.Draw()
+		app.QueueEvent(tcell.NewEventKey(256, 101, tcell.ModNone))
+		app.Draw()
+
+		// get and check commit options
+		commitOpts := commitDialog.GetContainerCommitOptions()
+		Expect(commitOpts.Image).To(Equal(opts.Image))
+		Expect(commitOpts.Author).To(Equal(opts.Author))
+		Expect(len(commitOpts.Changes)).To(Equal(len(opts.Change)))
+		Expect(commitOpts.Changes[0]).To(Equal(opts.Change[0]))
+		Expect(commitOpts.Changes[1]).To(Equal(opts.Change[1]))
+		Expect(commitOpts.Format).To(Equal(opts.Format))
+		Expect(commitOpts.Squash).To(Equal(opts.Squash))
+		Expect(commitOpts.Pause).To(Equal(opts.Squash))
+		Expect(commitOpts.Message).To(Equal(opts.Message))
+
+	})
+
+	AfterAll(func() {
+		app.Stop()
+	})
+
+})

--- a/ui/containers/draw.go
+++ b/ui/containers/draw.go
@@ -75,11 +75,16 @@ func (cnt *Containers) Draw(screen tcell.Screen) {
 		cnt.execTerminalDialog.Draw(screen)
 		return
 	}
-
 	// stats dialogs
 	if cnt.statsDialog.IsDisplay() {
 		cnt.statsDialog.SetRect(x, y, width, height)
 		cnt.statsDialog.Draw(screen)
+		return
+	}
+	// commit dialog
+	if cnt.commitDialog.IsDisplay() {
+		cnt.commitDialog.SetRect(x, y, width, height)
+		cnt.commitDialog.Draw(screen)
 		return
 	}
 }

--- a/ui/containers/key.go
+++ b/ui/containers/key.go
@@ -78,6 +78,13 @@ func (cnt *Containers) InputHandler() func(event *tcell.EventKey, setFocus func(
 			}
 		}
 
+		// container commit dialog handler
+		if cnt.commitDialog.HasFocus() {
+			if cntCommitDialogHandler := cnt.commitDialog.InputHandler(); cntCommitDialogHandler != nil {
+				cntCommitDialogHandler(event, setFocus)
+			}
+		}
+
 		// table handlers
 		if cnt.table.HasFocus() {
 			cnt.selectedID, cnt.selectedName = cnt.getSelectedItem()

--- a/ui/utils/style.go
+++ b/ui/utils/style.go
@@ -148,6 +148,10 @@ var Styles = theme{
 		BgColor:                tcell.ColorMediumPurple,
 		FgColor:                tcell.ColorWhite,
 	},
+	ContainerCommitDialog: containerCommitDialog{
+		BgColor: tcell.ColorMediumPurple,
+		FgColor: tcell.ColorWhite,
+	},
 	PodCreateDialog: podCreateDialog{
 		BgColor: tcell.ColorMediumPurple,
 		FgColor: tcell.ColorWhite,

--- a/ui/utils/style_windows.go
+++ b/ui/utils/style_windows.go
@@ -148,6 +148,10 @@ var Styles = theme{
 		BgColor:                tcell.ColorPink,
 		FgColor:                tcell.ColorWhite,
 	},
+	ContainerCommitDialog: containerCommitDialog{
+		BgColor: tcell.ColorPink,
+		FgColor: tcell.ColorWhite,
+	},
 	PodCreateDialog: podCreateDialog{
 		BgColor: tcell.ColorPink,
 		FgColor: tcell.ColorWhite,

--- a/ui/utils/theme.go
+++ b/ui/utils/theme.go
@@ -25,6 +25,7 @@ type theme struct {
 	ContainerExecDialog         containerExecDialog
 	ContainerExecTerminalDialog containerExecTerminalDialog
 	ContainerStatsDialog        containerStatsDialog
+	ContainerCommitDialog       containerCommitDialog
 	PodStatsDialog              podStatsDialog
 	PodCreateDialog             podCreateDialog
 	DropdownStyle               dropdownStyle
@@ -161,6 +162,11 @@ type containerCreateDialog struct {
 }
 
 type containerExecDialog struct {
+	BgColor tcell.Color
+	FgColor tcell.Color
+}
+
+type containerCommitDialog struct {
 	BgColor tcell.Color
 	FgColor tcell.Color
 }


### PR DESCRIPTION
Adding podman container commit command and supporting all available options except:
- "**include-volumes**": the option is not available under podman API but it looks like its part of libpod commit options. 
-  "**quiet**" and "**iidfile**": the new image ID will be displayed inside a message dialog therefore didn't add these options at this stage.

![container-commit](https://user-images.githubusercontent.com/5696685/172215190-97dee228-f530-4a7a-b55a-98d39cc4c0f6.jpeg)

Signed-off-by: Navid Yaghoobi <navidys@fedoraproject.org>