### PR TITLE
using binding/images.GetImage for image inspect

### DIFF
--- a/pdcs/images/inspect.go
+++ b/pdcs/images/inspect.go
@@ -1,8 +1,6 @@
 package images
 
 import (
-	"strings"
-
 	"github.com/containers/podman-tui/pdcs/registry"
 	"github.com/containers/podman-tui/pdcs/utils"
 	"github.com/containers/podman/v4/pkg/bindings/images"
@@ -17,19 +15,13 @@ func Inspect(id string) (string, error) {
 	if err != nil {
 		return report, err
 	}
-	response, err := images.List(conn, new(images.ListOptions).WithAll(true))
+	response, err := images.GetImage(conn, id, new(images.GetOptions))
 	if err != nil {
 		return report, err
 	}
-
-	for index, imgSumm := range response {
-		if strings.Index(imgSumm.ID, id) == 0 {
-			report, err = utils.GetJSONOutput(response[index])
-			if err != nil {
-				return report, err
-			}
-		}
-
+	report, err = utils.GetJSONOutput(response.ImageData)
+	if err != nil {
+		return report, err
 	}
 	log.Debug().Msgf("pdcs: %s", report)
 	return report, nil

--- a/test/001-image.bats
+++ b/test/001-image.bats
@@ -52,8 +52,8 @@ load helpers_tui
 }
 
 @test "image import" {
-    podman image rm busybox || echo done
-
+    /bin/rm -rf ${TEST_IMAGE_SAVE_PATH} || echo done
+    podman image save -o ${TEST_IMAGE_SAVE_PATH} busybox:latest || echo done
     # switch to images view
     # select import command from images commands dialog
     # fillout import path field


### PR DESCRIPTION
1. Using binding/images.GetImage function for image inspect.
2. Minor update on image import functionality tests. 

Signed-off-by: Navid Yaghoobi <navidys@fedoraproject.org>