### PR TITLE
infobar + help color update for headers

### DIFF
--- a/ui/utils/style.go
+++ b/ui/utils/style.go
@@ -19,8 +19,8 @@ var Styles = theme{
 		},
 	},
 	InfoBar: infoBar{
-		ItemFgColor:  tcell.ColorLightSlateGray,
-		ValueFgColor: tcell.ColorFloralWhite,
+		ItemFgColor:  tcell.ColorSilver,
+		ValueFgColor: tcell.ColorWhiteSmoke,
 		ProgressBar: progressBar{
 			FgColor:       tcell.ColorWhite,
 			BarEmptyColor: tcell.ColorWhite,
@@ -41,7 +41,7 @@ var Styles = theme{
 		BorderColor:   tcell.ColorMediumPurple,
 		BgColor:       tview.Styles.PrimitiveBackgroundColor,
 		FgColor:       tcell.ColorWhiteSmoke,
-		HeaderFgColor: tcell.ColorLightSlateGray,
+		HeaderFgColor: tcell.ColorSilver,
 	},
 	ConnectionProgressDialog: connectionProgressDialog{
 		BgColor:     tcell.ColorMediumPurple,


### PR DESCRIPTION
Changing Infobar and help page item's header color to "Silver", previous color "SlateGray" was too dark.
 
**Before:**
![before](https://user-images.githubusercontent.com/5696685/172422759-8a22040f-0d01-44d9-b418-288dd888c726.png)

**After:**
![after](https://user-images.githubusercontent.com/5696685/172422868-05f2d0ba-ce14-4546-9214-d780a70da4fe.jpeg)

Signed-off-by: Navid Yaghoobi <navidys@fedoraproject.org>