### PR TITLE
Esc key shall not close dialogs if its dropdown widget has focus

### DIFF
--- a/ui/containers/cntdialogs/create.go
+++ b/ui/containers/cntdialogs/create.go
@@ -482,6 +482,21 @@ func (d *ContainerCreateDialog) HasFocus() bool {
 	return d.Box.HasFocus() || d.form.HasFocus()
 }
 
+// dropdownHasFocus returns true if container create dialog dropdown primitives
+// has focus
+func (d *ContainerCreateDialog) dropdownHasFocus() bool {
+	if d.containerImageField.HasFocus() || d.containerPodField.HasFocus() {
+		return true
+	}
+	if d.containerVolumeField.HasFocus() || d.containerImageVolumeField.HasFocus() {
+		return true
+	}
+	if d.containerNetworkField.HasFocus() {
+		return true
+	}
+	return false
+}
+
 // Focus is called when this primitive receives focus
 func (d *ContainerCreateDialog) Focus(delegate func(p tview.Primitive)) {
 	switch d.focusElement {
@@ -612,7 +627,7 @@ func (d *ContainerCreateDialog) initCustomInputHanlers() {
 func (d *ContainerCreateDialog) InputHandler() func(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
 	return d.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
 		log.Debug().Msgf("container create dialog: event %v received", event)
-		if event.Key() == tcell.KeyEsc {
+		if event.Key() == tcell.KeyEsc && !d.dropdownHasFocus() {
 			d.cancelHandler()
 			return
 		}

--- a/ui/pods/poddialogs/create.go
+++ b/ui/pods/poddialogs/create.go
@@ -432,6 +432,12 @@ func (d *PodCreateDialog) HasFocus() bool {
 	return d.Box.HasFocus() || d.form.HasFocus()
 }
 
+// dropdownHasFocus returns true if pod create dialog dropdown primitives
+// has focus
+func (d *PodCreateDialog) dropdownHasFocus() bool {
+	return d.podNetworkField.HasFocus()
+}
+
 // Focus is called when this primitive receives focus
 func (d *PodCreateDialog) Focus(delegate func(p tview.Primitive)) {
 	switch d.focusElement {
@@ -529,7 +535,7 @@ func (d *PodCreateDialog) initCustomInputHanlers() {
 func (d *PodCreateDialog) InputHandler() func(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
 	return d.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
 		log.Debug().Msgf("pod create dialog: event %v received", event)
-		if event.Key() == tcell.KeyEsc {
+		if event.Key() == tcell.KeyEsc && !d.dropdownHasFocus() {
 			d.cancelHandler()
 			return
 		}


### PR DESCRIPTION
Esc key event is used to:
1. close (hide) different dialogs.
2. hide the dropdown widget items.

on container and pod create dialogs while dropdown widgest have focus, the Esc key shall not close the create dialog and instead it shall only hide the dropdown list.

Signed-off-by: Navid Yaghoobi <navidys@fedoraproject.org>