### PR TITLE
disk usage dialog table headers color update

### DIFF
--- a/ui/utils/style.go
+++ b/ui/utils/style.go
@@ -185,8 +185,8 @@ var Styles = theme{
 		BgColor: tcell.ColorMediumPurple,
 		FgColor: tcell.ColorDimGray,
 		HeaderRow: headerRow{
-			FgColor: tcell.ColorDarkMagenta,
-			BgColor: tcell.ColorMediumPurple,
+			FgColor: tcell.ColorWhite,
+			BgColor: tcell.ColorRebeccaPurple,
 		},
 	},
 	MessageDialog: messageDialog{


### PR DESCRIPTION
All the different dialogs are using consistent color style except disk usage dialog.  
Table header color style  (disk usage dialog) has been updated to be same as other dialogs. 

![disk_usage_after](https://user-images.githubusercontent.com/5696685/172655034-7edb3abe-68ec-4fdd-9d75-f9d8c8dc32bd.png)

**previous style:**
![disk_usage_before](https://user-images.githubusercontent.com/5696685/172655068-87e0aefa-9a78-4bec-b5a3-2b8498e44535.png)



Signed-off-by: Navid Yaghoobi <navidys@fedoraproject.org>