### PR TITLE
show confirmation dialog in the center of different views

### DIFF
--- a/ui/dialogs/confirm.go
+++ b/ui/dialogs/confirm.go
@@ -127,10 +127,9 @@ func (d *ConfirmDialog) setRect() {
 		d.height = maxHeight
 		layoutHeight = d.height - DialogFormHeight - 2
 	}
-
 	if maxHeight > d.height {
 		emptyHeight := (maxHeight - d.height) / 2
-		d.y = d.y + emptyHeight - DialogPadding
+		d.y = d.y + emptyHeight
 
 	}
 
@@ -141,10 +140,9 @@ func (d *ConfirmDialog) setRect() {
 			d.width = messageWidth + 2
 		}
 	}
-
 	if maxWidth > d.width {
 		emptyWidth := (maxWidth - d.width) / 2
-		d.x = d.x + emptyWidth + DialogPadding
+		d.x = d.x + emptyWidth
 	}
 
 	d.layout.Clear()


### PR DESCRIPTION
All the dialogs shall be displayed in center of different views and not in center of the terminal. 
Confirmation message dialog was not displayed in the center of the view/page due to extra dialog padding. 

![confirmaion dialog after](https://user-images.githubusercontent.com/5696685/172668858-e2a2754e-f06b-4216-88eb-01d0a77a2194.png)

**Before PR:**

![confimation dialog before](https://user-images.githubusercontent.com/5696685/172668952-38b9f14b-5ffa-4d6f-b033-99543440bb82.png)


Signed-off-by: Navid Yaghoobi <navidys@fedoraproject.org>