### PR TITLE
Makefile - install golangci-lint and codespell tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ uninstall:  ## Uninstall podman-tui binary
 install.tools: .install.ginkgo .install.bats .install.pre-commit ## Install needed tools
 
 .PHONY: .install.ginkgo
-.install.ginkgo: .gopathok
+.install.ginkgo:
 	if [ ! -x "$(GOBIN)/ginkgo" ]; then \
 		$(GO) install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.1.4 ; \
 	fi
@@ -83,6 +83,14 @@ install.tools: .install.ginkgo .install.bats .install.pre-commit ## Install need
 	if [ -z "$(PRE_COMMIT)" ]; then \
 		python3 -m pip install --user pre-commit; \
 	fi
+
+.PHONY: .install.golangci-lint
+.install.golangci-lint:
+	VERSION=1.46.2 ./hack/install_golangci.sh
+
+.PHONY: .install.codespell
+.install.codespell:
+	sudo ${PKG_MANAGER} -y install codespell
 
 #=================================================
 # Testing (units, functionality, ...) targets
@@ -122,12 +130,6 @@ package-install: package  ## Install rpm package
 #=================================================
 # Linting/Formatting/Code Validation targets
 #=================================================
-
-.gopathok:
-ifeq ("$(wildcard $(GOPKGDIR))","")
-	mkdir -p "$(GOPKGBASEDIR)"
-	ln -sfn "$(CURDIR)" "$(GOPKGDIR)"
-endif
 
 .PHONY: validate
 validate: gofmt lint pre-commit  ## Validate podman-tui code (fmt, lint, ...)

--- a/hack/install_golangci.sh
+++ b/hack/install_golangci.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# code from: https://raw.githubusercontent.com/containers/podman/main/hack/install_golangci.sh
+die() { echo "${1:-No error message given} (from $(basename $0))"; exit 1; }
+
+[ -n "$VERSION" ] || die "\$VERSION is empty or undefined"
+
+function install() {
+    echo "Installing golangci-lint v$VERSION into $BIN"
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v$VERSION
+}
+
+BIN="./bin/golangci-lint"
+if [ ! -x "$BIN" ]; then
+	install
+else
+    # Prints its own file name as part of --version output
+    $BIN --version | grep "$VERSION"
+    if [ $? -eq 0 ]; then
+        echo "Using existing $(dirname $BIN)/$($BIN --version)"
+    else
+        install
+    fi
+fi


### PR DESCRIPTION
Adding codespell and golangci-lint installation to Makefile.

Signed-off-by: Navid Yaghoobi <navidys@fedoraproject.org>