### PR TITLE
Bump 0.6.0

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	appVersion = "0.6.0"
+	appVersion = "0.7.0-dev"
 )
 
 // versionCmd represents the version command

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	appVersion = "0.6.0-dev"
+	appVersion = "0.6.0"
 )
 
 // versionCmd represents the version command

--- a/podman-tui.spec.rpkg
+++ b/podman-tui.spec.rpkg
@@ -16,7 +16,7 @@
 
 Name: podman-tui
 Version: 0.6.0
-Release: dev.1%{?dist}
+Release: 1%{?dist}
 Summary: Podman Terminal User Interface
 License: ASL 2.0
 URL: %{git0}
@@ -66,7 +66,35 @@ install -p ./bin/%{name} %{buildroot}%{_bindir}
 %{_bindir}/%{name}
 
 %changelog
-* Sat Jul 02 2022 Navid Yaghoobi <navidys@fedoraproject.org> 0.6.0-dev-1
+* Sun Sep 11 2022 Navid Yaghoobi <navidys@fedoraproject.org> 0.6.0-1
+- new feature - network disconnect
+- adding approvers to OWNERS file + running codespell
+- new feature - network connect
+- Fix flaky tests
+- Fix typos
+- Running golangci-lint on pdcs/pods, pcs/containers
+- running golangci-lint on pdcs/images
+- Makefile target to run codespell
+- running golangci-lint on pdcs/sysinfo
+- running golangci-lint on pdcs/networks
+- running golangci-lint on pdcs/volumes
+- running golangci-lint on pdcs/registry and pdcs/utils
+- Makefile - install golangci-lint and codespell tools
+- Bump github.com/containers/podman/v4 from 4.2.0 to 4.2.1
+- Bump github.com/docker/go-units from 0.4.0 to 0.5.0
+- Bump github.com/onsi/gomega from 1.20.1 to 1.20.2
+- Bump github.com/onsi/ginkgo/v2 from 2.1.4 to 2.1.6
+- Bump github.com/rs/zerolog from 1.27.0 to 1.28.0
+- Bump github.com/containers/podman/v4 from 4.1.1 to 4.2.0
+- Bump github.com/containers/buildah from 1.26.4 to 1.27.0
+- Bump github.com/containers/buildah from 1.26.2 to 1.26.4
+- Bump github.com/containers/common from 0.48.0 to 0.49.0
+- Bump github.com/containers/storage from 1.41.0 to 1.42.0
+- Bump github.com/BurntSushi/toml from 1.1.0 to 1.2.0
+- Bump github.com/onsi/gomega from 1.19.0 to 1.20.0
+- Bump github.com/sirupsen/logrus from 1.8.1 to 1.9.0
+- Bump github.com/containers/buildah from 1.26.1 to 1.26.2
+- Bump github.com/navidys/tvxwidgets from 0.1.0 to 0.1.1
 
 * Sat Jul 02 2022 Navid Yaghoobi <navidys@fedoraproject.org> 0.5.0-1
 - feature - image push

--- a/podman-tui.spec.rpkg
+++ b/podman-tui.spec.rpkg
@@ -15,8 +15,8 @@
 %global git0 https://%{import_path}
 
 Name: podman-tui
-Version: 0.6.0
-Release: 1%{?dist}
+Version: 0.7.0
+Release: dev.1%{?dist}
 Summary: Podman Terminal User Interface
 License: ASL 2.0
 URL: %{git0}
@@ -66,6 +66,8 @@ install -p ./bin/%{name} %{buildroot}%{_bindir}
 %{_bindir}/%{name}
 
 %changelog
+* Sun Sep 11 2022 Navid Yaghoobi <navidys@fedoraproject.org> 0.7.0-dev-1
+
 * Sun Sep 11 2022 Navid Yaghoobi <navidys@fedoraproject.org> 0.6.0-1
 - new feature - network disconnect
 - adding approvers to OWNERS file + running codespell


### PR DESCRIPTION
release 0.6.0:
- new feature - network disconnect
- adding approvers to OWNERS file + running codespell
- new feature - network connect
- Fix flaky tests
- Fix typos
- Running golangci-lint on pdcs/pods, pcs/containers
- running golangci-lint on pdcs/images
- Makefile target to run codespell
- running golangci-lint on pdcs/sysinfo
- running golangci-lint on pdcs/networks
- running golangci-lint on pdcs/volumes
- running golangci-lint on pdcs/registry and pdcs/utils
- Makefile - install golangci-lint and codespell tools
- Bump github.com/containers/podman/v4 from 4.2.0 to 4.2.1
- Bump github.com/docker/go-units from 0.4.0 to 0.5.0
- Bump github.com/onsi/gomega from 1.20.1 to 1.20.2
- Bump github.com/onsi/ginkgo/v2 from 2.1.4 to 2.1.6
- Bump github.com/rs/zerolog from 1.27.0 to 1.28.0
- Bump github.com/containers/podman/v4 from 4.1.1 to 4.2.0
- Bump github.com/containers/buildah from 1.26.4 to 1.27.0
- Bump github.com/containers/buildah from 1.26.2 to 1.26.4
- Bump github.com/containers/common from 0.48.0 to 0.49.0
- Bump github.com/containers/storage from 1.41.0 to 1.42.0
- Bump github.com/BurntSushi/toml from 1.1.0 to 1.2.0
- Bump github.com/onsi/gomega from 1.19.0 to 1.20.0
- Bump github.com/sirupsen/logrus from 1.8.1 to 1.9.0
- Bump github.com/containers/buildah from 1.26.1 to 1.26.2
- Bump github.com/navidys/tvxwidgets from 0.1.0 to 0.1.1