### PR TITLE
fix test failure for utils and network disconnect dialog

### DIFF
--- a/ui/networks/netdialogs/disconnect_test.go
+++ b/ui/networks/netdialogs/disconnect_test.go
@@ -114,6 +114,7 @@ var _ = Describe("network disconnect", Ordered, func() {
 		netDisconnectDialog.Display()
 		netDisconnectDialogApp.SetFocus(netDisconnectDialog)
 		netDisconnectDialogApp.Draw()
+		netDisconnectDialogApp.SetFocus(netDisconnectDialog)
 
 		netDisconnectDialogApp.QueueEvent(tcell.NewEventKey(tcell.KeyTAB, 0, tcell.ModNone))
 		netDisconnectDialogApp.Draw()

--- a/ui/utils/utils_test.go
+++ b/ui/utils/utils_test.go
@@ -37,10 +37,10 @@ var _ = Describe("utils", func() {
 			panic(err)
 		}
 
-		path01 := path.Join("/home", user.Username, "path01")
+		path01 := path.Join(user.HomeDir, "path01")
 		path01Wants := path01
 		path02 := "~/path02"
-		path02Wants := path.Join("/home", user.Username, "path02")
+		path02Wants := path.Join(user.HomeDir, "path02")
 
 		path01Resolv, err := ResolveHomeDir(path01)
 		Expect(path01Resolv).To(Equal(path01Wants))


### PR DESCRIPTION
The PR will fix:
- test failure when user home directory is not "/home" #156 
- test failure of network disconnect dialog get options

Signed-off-by: Navid Yaghoobi <navidys@fedoraproject.org>