### PR TITLE
config and pdcs update for podman v4.3.0

### DIFF
--- a/test/005-container.bats
+++ b/test/005-container.bats
@@ -175,14 +175,14 @@ load helpers_tui
     # selec restore command from container commands dialog
     # filleout information
     # go to restire button and Enter
-    
+
     podman_tui_set_view "containers"
     podman_tui_select_container_cmd "restore"
     podman_tui_send_inputs "Tab" "Tab"
     podman_tui_send_inputs ${TEST_CONTAINER_CHECKPOINT_NAME}_restore
     podman_tui_send_inputs "Tab" "Tab"
     podman_tui_send_inputs "~/${TEST_CONTAINER_CHECKPOINT_NAME}_dump.tar"
-    podman_tui_send_inputs "Tab" "Tab" "Tab" "Tab" 
+    podman_tui_send_inputs "Tab" "Tab" "Tab" "Tab"
     podman_tui_send_inputs "Tab" "Tab" "Tab" "Tab"
     podman_tui_send_inputs "Tab" "Tab" "Enter"
 


### PR DESCRIPTION
config and pdcs packages update to adopt with following API changes in podman (v4.3.0):

- containers/podman/v4/pkg/bindings:  "CONTAINER_PASSPHRASE" environemnt variabel support removal
- containers/podman/v4/pkg/terminal: "PublicKey" function has been moved to containers/common/pkg/ssh. 

Signed-off-by: Navid Yaghoobi <navidys@fedoraproject.org>