### PR TITLE
removing empty first row in container and network UI create dialogs

### DIFF
--- a/ui/containers/cntdialogs/create.go
+++ b/ui/containers/cntdialogs/create.go
@@ -361,7 +361,6 @@ func NewContainerCreateDialog() *ContainerCreateDialog {
 	containerDialog.form.SetButtonsAlign(tview.AlignRight)
 	containerDialog.form.SetButtonBackgroundColor(style.ButtonBgColor)
 
-	containerDialog.layout.AddItem(tview.NewBox().SetBackgroundColor(bgColor), 1, 0, true)
 	containerDialog.setupLayout()
 	containerDialog.layout.SetBackgroundColor(bgColor)
 	containerDialog.layout.SetBorder(true)

--- a/ui/networks/netdialogs/create.go
+++ b/ui/networks/netdialogs/create.go
@@ -192,7 +192,6 @@ func NewNetworkCreateDialog() *NetworkCreateDialog {
 	netDialog.form.SetButtonsAlign(tview.AlignRight)
 	netDialog.form.SetButtonBackgroundColor(buttonBgColor)
 
-	netDialog.layout.AddItem(tview.NewBox().SetBackgroundColor(bgColor), 1, 0, true)
 	netDialog.setupLayout()
 	netDialog.layout.SetBackgroundColor(bgColor)
 	netDialog.layout.SetBorder(true)


### PR DESCRIPTION
before change:

![before_change](https://user-images.githubusercontent.com/5696685/208221474-2b8ee0f3-8c4c-4e19-a389-f68a65b4c4f3.png)

after change:

![after_change](https://user-images.githubusercontent.com/5696685/208221478-3f2061ab-c29d-41c9-8ae8-a5a117375b20.png)

Signed-off-by: Navid Yaghoobi <navidys@fedoraproject.org>