### PR TITLE
packit update - remove centos9 stream RPM build (EPEL9 available)

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -14,7 +14,6 @@ jobs:
     targets:
       - fedora-all
       - epel-9
-      - centos-stream-9
     actions:
       post-upstream-clone:
         - "rpkg spec --outdir ./"


### PR DESCRIPTION
Removing centos9 stream RPM build from packit, we are build EPEL9 already.