### PR TITLE
Bump 0.13.0

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	appVersion = "0.13.0"
+	appVersion = "0.14.0-dev"
 )
 
 // versionCmd represents the version command.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	appVersion = "0.13.0-dev"
+	appVersion = "0.13.0"
 )
 
 // versionCmd represents the version command.

--- a/podman-tui.spec.rpkg
+++ b/podman-tui.spec.rpkg
@@ -16,7 +16,7 @@
 
 Name: podman-tui
 Version: 0.13.0
-Release: dev.1%{?dist}
+Release: 1%{?dist}
 Summary: Podman Terminal User Interface
 License: ASL 2.0
 URL: %{git0}
@@ -60,7 +60,21 @@ install -p ./bin/%{name} %{buildroot}%{_bindir}
 %{_bindir}/%{name}
 
 %changelog
-* Sat Nov 11 2023 Navid Yaghoobi <navidys@fedoraproject.org> 0.13.0-dev-1
+* Fri Dec 01 2023 Navid Yaghoobi <navidys@fedoraproject.org> 0.13.0-1
+- EPEL rpm package
+- Adding container create mount inputfield option
+- Use inputfield for container create volume option
+- Github action update
+- Docs update - add Gentoo in packaged versions
+- Running golangci-lint on ui package
+- Running golangci-lint on app package
+- Running golangci-lint on config package
+- Running golangci-lint on cmd package
+- Bump github.com/containers/podman/v4 from 4.7.2 to 4.8.0
+- Bump golang.org/x/crypto from 0.15.0 to 0.16.0
+- Bump github.com/navidys/tvxwidgets from 0.4.0 to 0.4.1
+- Bump github.com/go-jose/go-jose/v3 from 3.0.0 to 3.0.1
+- Bump github.com/containers/storage from 1.50.2 to 1.51.0
 
 * Sat Nov 11 2023 Navid Yaghoobi <navidys@fedoraproject.org> 0.12.0-1
 - Bump github.com/containers/buildah from 1.31.2 to 1.32.2

--- a/podman-tui.spec.rpkg
+++ b/podman-tui.spec.rpkg
@@ -15,8 +15,8 @@
 %global git0 https://%{import_path}
 
 Name: podman-tui
-Version: 0.13.0
-Release: 1%{?dist}
+Version: 0.14.0
+Release: dev.1%{?dist}
 Summary: Podman Terminal User Interface
 License: ASL 2.0
 URL: %{git0}
@@ -60,6 +60,8 @@ install -p ./bin/%{name} %{buildroot}%{_bindir}
 %{_bindir}/%{name}
 
 %changelog
+* Fri Dec 01 2023 Navid Yaghoobi <navidys@fedoraproject.org> 0.14.0-dev-1
+
 * Fri Dec 01 2023 Navid Yaghoobi <navidys@fedoraproject.org> 0.13.0-1
 - EPEL rpm package
 - Adding container create mount inputfield option


### PR DESCRIPTION
- EPEL rpm package
- Adding container create mount inputfield option
- Use inputfield for container create volume option
- Github action update
- Docs update - add Gentoo in packaged versions
- Running golangci-lint on ui package
- Running golangci-lint on app package
- Running golangci-lint on config package
- Running golangci-lint on cmd package
- Bump github.com/containers/podman/v4 from 4.7.2 to 4.8.0
- Bump golang.org/x/crypto from 0.15.0 to 0.16.0
- Bump github.com/navidys/tvxwidgets from 0.4.0 to 0.4.1
- Bump github.com/go-jose/go-jose/v3 from 3.0.0 to 3.0.1
- Bump github.com/containers/storage from 1.50.2 to 1.51.0