### PR TITLE
Bump 0.16.0

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	appVersion = "0.16.0"
+	appVersion = "0.17.0-dev"
 )
 
 // versionCmd represents the version command.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	appVersion = "0.16.0-dev"
+	appVersion = "0.16.0"
 )
 
 // versionCmd represents the version command.

--- a/podman-tui.spec.rpkg
+++ b/podman-tui.spec.rpkg
@@ -15,8 +15,8 @@
 %global git0 https://%{import_path}
 
 Name: podman-tui
-Version: 0.16.0
-Release: 1%{?dist}
+Version: 0.17.0
+Release: dev.1%{?dist}
 Summary: Podman Terminal User Interface
 License: ASL 2.0
 URL: %{git0}
@@ -60,6 +60,8 @@ install -p ./bin/%{name} %{buildroot}%{_bindir}
 %{_bindir}/%{name}
 
 %changelog
+* Sun Jan 21 2024 Navid Yaghoobi <navidys@fedoraproject.org> 0.17.0-dev-1
+
 * Sun Jan 21 2024 Navid Yaghoobi <navidys@fedoraproject.org> 0.16.0-1
 - Bump github.com/containers/podman/v4 from 4.8.2 to 4.8.3
 - Bump github.com/containerd/containerd from 1.7.9 to 1.7.11

--- a/podman-tui.spec.rpkg
+++ b/podman-tui.spec.rpkg
@@ -16,7 +16,7 @@
 
 Name: podman-tui
 Version: 0.16.0
-Release: dev.1%{?dist}
+Release: 1%{?dist}
 Summary: Podman Terminal User Interface
 License: ASL 2.0
 URL: %{git0}
@@ -60,7 +60,11 @@ install -p ./bin/%{name} %{buildroot}%{_bindir}
 %{_bindir}/%{name}
 
 %changelog
-* Wed Dec 20 2023 Navid Yaghoobi <navidys@fedoraproject.org> 0.16.0-dev-1
+* Sun Jan 21 2024 Navid Yaghoobi <navidys@fedoraproject.org> 0.16.0-1
+- Bump github.com/containers/podman/v4 from 4.8.2 to 4.8.3
+- Bump github.com/containerd/containerd from 1.7.9 to 1.7.11
+- Bump golang.org/x/crypto from 0.17.0 to 0.18.0
+- Bump github.com/containers/common from 0.57.1 to 0.57.2
 
 * Wed Dec 20 2023 Navid Yaghoobi <navidys@fedoraproject.org> 0.15.0-1
 - Bump golang.org/x/crypto from 0.16.0 to 0.17.0 [CVE-2023-48795]


### PR DESCRIPTION
- Bump github.com/containers/podman/v4 from 4.8.2 to 4.8.3
- Bump github.com/containerd/containerd from 1.7.9 to 1.7.11
- Bump golang.org/x/crypto from 0.17.0 to 0.18.0
- Bump github.com/containers/common from 0.57.1 to 0.57.2