### PR TITLE
Bump 0.18.0

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	appVersion = "0.18.0"
+	appVersion = "0.19.0-dev"
 )
 
 // versionCmd represents the version command.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	appVersion = "0.18.0-dev"
+	appVersion = "0.18.0"
 )
 
 // versionCmd represents the version command.

--- a/podman-tui.spec.rpkg
+++ b/podman-tui.spec.rpkg
@@ -15,8 +15,8 @@
 %global git0 https://%{import_path}
 
 Name: podman-tui
-Version: 0.18.0
-Release: 1%{?dist}
+Version: 0.19.0
+Release: dev.1%{?dist}
 Summary: Podman Terminal User Interface
 License: ASL 2.0
 URL: %{git0}
@@ -60,6 +60,8 @@ install -p ./bin/%{name} %{buildroot}%{_bindir}
 %{_bindir}/%{name}
 
 %changelog
+* Sat Mar 16 2024 Navid Yaghoobi <navidys@fedoraproject.org> 0.19.0-dev-1
+
 * Sat Mar 16 2024 Navid Yaghoobi <navidys@fedoraproject.org> 0.18.0-1
 - Resolves Substitute env variables in config file
 - Golangci-lint update 1.56.2

--- a/podman-tui.spec.rpkg
+++ b/podman-tui.spec.rpkg
@@ -60,7 +60,27 @@ install -p ./bin/%{name} %{buildroot}%{_bindir}
 %{_bindir}/%{name}
 
 %changelog
-* Sun Feb 04 2024 Navid Yaghoobi <navidys@fedoraproject.org> 0.18.0-dev-1
+* Sat Mar 16 2024 Navid Yaghoobi <navidys@fedoraproject.org> 0.18.0-1
+- Resolves Substitute env variables in config file
+- Golangci-lint update 1.56.2
+- Unit tests
+- Vagrantfile update (fedora 39)
+- Github action update
+- podman-tui installation via homebrew for Mac
+- install.md update - ArchLinux (AUR)
+- install.md update - Alpine Linux, AlmaLinux and Rocky Linux
+- README.md update
+- Bump github.com/containers/podman/v4 from 4.9.2 to 4.9.3
+- Bump github.com/gdamore/tcell/v2 from 2.7.0 to 2.7.4
+- Bump golang.org/x/crypto from 0.19.0 to 0.21.0
+- Bump tim-actions/get-pr-commits from 1.3.0 to 1.3.1
+- Bump codecov/codecov-action from 3 to 4
+- Bump golang.org/x/crypto from 0.18.0 to 0.19.0
+- Bump pre-commit/action from 3.0.0 to 3.0.1
+- Bump github.com/rs/zerolog from 1.31.0 to 1.32.0
+- Bump google.golang.org/protobuf from 1.31.0 to 1.33.0
+- Bump github.com/go-jose/go-jose/v3 from 3.0.1 to 3.0.3
+- Bump gopkg.in/go-jose/go-jose.v2 from 2.6.1 to 2.6.3
 
 * Sun Feb 04 2024 Navid Yaghoobi <navidys@fedoraproject.org> 0.17.0-1
 - Bump github.com/containers/podman/v4 to 4.9.2


### PR DESCRIPTION
- Resolves Substitute env variables in config file
- Golangci-lint update 1.56.2
- Unit tests
- Vagrantfile update (fedora 39)
- Github action update
- podman-tui installation via homebrew for Mac
- install.md update - ArchLinux (AUR)
- install.md update - Alpine Linux, AlmaLinux and Rocky Linux
- README.md update
- Bump github.com/containers/podman/v4 from 4.9.2 to 4.9.3
- Bump github.com/gdamore/tcell/v2 from 2.7.0 to 2.7.4
- Bump golang.org/x/crypto from 0.19.0 to 0.21.0
- Bump tim-actions/get-pr-commits from 1.3.0 to 1.3.1
- Bump codecov/codecov-action from 3 to 4
- Bump golang.org/x/crypto from 0.18.0 to 0.19.0
- Bump pre-commit/action from 3.0.0 to 3.0.1
- Bump github.com/rs/zerolog from 1.31.0 to 1.32.0
- Bump google.golang.org/protobuf from 1.31.0 to 1.33.0
- Bump github.com/go-jose/go-jose/v3 from 3.0.1 to 3.0.3 [CVE-2024-28180]
- Bump gopkg.in/go-jose/go-jose.v2 from 2.6.1 to 2.6.3 [CVE-2024-28180]
