### PR TITLE
Bump 1.1.0

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	appVersion = "1.1.0"
+	appVersion = "1.2.0-dev"
 )
 
 // versionCmd represents the version command.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	appVersion = "1.1.0-dev"
+	appVersion = "1.1.0"
 )
 
 // versionCmd represents the version command.

--- a/podman-tui.spec.rpkg
+++ b/podman-tui.spec.rpkg
@@ -15,8 +15,8 @@
 %global git0 https://%{import_path}
 
 Name: podman-tui
-Version: 1.1.0
-Release: 1%{?dist}
+Version: 1.2.0
+Release: dev.1%{?dist}
 Summary: Podman Terminal User Interface
 License: ASL 2.0
 URL: %{git0}
@@ -60,6 +60,8 @@ install -p ./bin/%{name} %{buildroot}%{_bindir}
 %{_bindir}/%{name}
 
 %changelog
+* Sun Jun 02 2024 Navid Yaghoobi <navidys@fedoraproject.org> 1.2.0-dev-1
+
 * Sun Jun 02 2024 Navid Yaghoobi <navidys@fedoraproject.org> 1.1.0-1
 - Bump github.com/containers/podman from 5.0.3 to 5.1.0
 - Bump github.com/containers/buildah from 1.35.4 to 1.36.0

--- a/podman-tui.spec.rpkg
+++ b/podman-tui.spec.rpkg
@@ -16,7 +16,7 @@
 
 Name: podman-tui
 Version: 1.1.0
-Release: dev.1%{?dist}
+Release: 1%{?dist}
 Summary: Podman Terminal User Interface
 License: ASL 2.0
 URL: %{git0}
@@ -60,7 +60,13 @@ install -p ./bin/%{name} %{buildroot}%{_bindir}
 %{_bindir}/%{name}
 
 %changelog
-* Sat May 11 2024 Navid Yaghoobi <navidys@fedoraproject.org> 1.1.0-dev-1
+* Sun Jun 02 2024 Navid Yaghoobi <navidys@fedoraproject.org> 1.1.0-1
+- Bump github.com/containers/podman from 5.0.3 to 5.1.0
+- Bump github.com/containers/buildah from 1.35.4 to 1.36.0
+- Bump github.com/containers/storage from 1.53.0 to 1.54.0
+- Bump github.com/containers/common from 0.58.3 to 0.59.0
+- Bump github.com/BurntSushi/toml from 1.3.2 to 1.4.0
+- Bump github.com/rs/zerolog from 1.32.0 to 1.33.0
 
 * Sat May 11 2024 Navid Yaghoobi <navidys@fedoraproject.org> 1.0.1-1
 - Bump github.com/containers/podman/v5 from 5.0.0 to 5.0.3


### PR DESCRIPTION
- Bump github.com/containers/podman from 5.0.3 to 5.1.0
- Bump github.com/containers/buildah from 1.35.4 to 1.36.0
- Bump github.com/containers/storage from 1.53.0 to 1.54.0
- Bump github.com/containers/common from 0.58.3 to 0.59.0
- Bump github.com/BurntSushi/toml from 1.3.2 to 1.4.0
- Bump github.com/rs/zerolog from 1.32.0 to 1.33.0