### PR TITLE
Bump 1.2.0

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	appVersion = "1.2.0-dev"
+	appVersion = "1.2.0"
 )
 
 // versionCmd represents the version command.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	appVersion = "1.2.0"
+	appVersion = "1.3.0-dev"
 )
 
 // versionCmd represents the version command.

--- a/podman-tui.spec.rpkg
+++ b/podman-tui.spec.rpkg
@@ -15,8 +15,8 @@
 %global git0 https://%{import_path}
 
 Name: podman-tui
-Version: 1.2.0
-Release: 1%{?dist}
+Version: 1.3.0
+Release: dev.1%{?dist}
 Summary: Podman Terminal User Interface
 License: ASL 2.0
 URL: %{git0}
@@ -60,6 +60,8 @@ install -p ./bin/%{name} %{buildroot}%{_bindir}
 %{_bindir}/%{name}
 
 %changelog
+* Sat Aug 03 2024 Navid Yaghoobi <navidys@fedoraproject.org> 1.3.0-dev-1
+
 * Sat Aug 03 2024 Navid Yaghoobi <navidys@fedoraproject.org> 1.2.0-1
 - New feature - secrets page
 - Secret create and remove command

--- a/podman-tui.spec.rpkg
+++ b/podman-tui.spec.rpkg
@@ -16,7 +16,7 @@
 
 Name: podman-tui
 Version: 1.2.0
-Release: dev.1%{?dist}
+Release: 1%{?dist}
 Summary: Podman Terminal User Interface
 License: ASL 2.0
 URL: %{git0}
@@ -60,7 +60,19 @@ install -p ./bin/%{name} %{buildroot}%{_bindir}
 %{_bindir}/%{name}
 
 %changelog
-* Sun Jun 02 2024 Navid Yaghoobi <navidys@fedoraproject.org> 1.2.0-dev-1
+* Sat Aug 03 2024 Navid Yaghoobi <navidys@fedoraproject.org> 1.2.0-1
+- New feature - secrets page
+- Secret create and remove command
+- Fix container exec error dialog hang
+- Packit targets update
+- Vagrant update to fedora 40
+- Go version update 1.21.0
+- README.md update
+- Bump github.com/containers/podman/v5 from 5.1.0 to 5.2.0
+- Bump github.com/containers/common from 0.59.1 to 0.59.2
+- Bump golang.org/x/crypto from 0.23.0 to 0.25.0
+- Bump github.com/gorilla/schema from 1.3.0 to 1.4.1
+- Bump github.com/spf13/cobra from 1.8.0 to 1.8.1
 
 * Sun Jun 02 2024 Navid Yaghoobi <navidys@fedoraproject.org> 1.1.0-1
 - Bump github.com/containers/podman from 5.0.3 to 5.1.0


### PR DESCRIPTION
- New feature - secrets page
- Secret create and remove command
- Fix container exec error dialog hang
- Packit targets update
- Vagrant update to fedora 40
- Go version update 1.21.0
- README.md update
- Bump github.com/containers/podman/v5 from 5.1.0 to 5.2.0
- Bump github.com/containers/common from 0.59.1 to 0.59.2
- Bump golang.org/x/crypto from 0.23.0 to 0.25.0
- Bump github.com/gorilla/schema from 1.3.0 to 1.4.1
- Bump github.com/spf13/cobra from 1.8.0 to 1.8.1

