### PR TITLE
Bump 1.9.0

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	appVersion = "1.9.0"
+	appVersion = "1.10.0-dev"
 )
 
 // versionCmd represents the version command.

--- a/podman-tui.spec.rpkg
+++ b/podman-tui.spec.rpkg
@@ -15,8 +15,8 @@
 %global git0 https://%{import_path}
 
 Name: podman-tui
-Version: 1.9.0
-Release: 1%{?dist}
+Version: 1.10.0
+Release: dev.1%{?dist}
 Summary: Podman Terminal User Interface
 License: ASL 2.0
 URL: %{git0}
@@ -60,6 +60,8 @@ install -p ./bin/%{name} %{buildroot}%{_bindir}
 %{_bindir}/%{name}
 
 %changelog
+* Sat Oct 04 2025 Navid Yaghoobi <navidys@fedoraproject.org> 1.10.0-dev-1
+
 * Sat Oct 04 2025 Navid Yaghoobi <navidys@fedoraproject.org> 1.9.0-1
 - Bump github.com/navidys/tvxwidgets from 0.4.1 to 0.12.1
 - Bump golang to 1.24.7 - CVE-2025-47910 and CVE-2025-47906


### PR DESCRIPTION
- Bump github.com/navidys/tvxwidgets from 0.4.1 to 0.12.1
- Bump golang to 1.24.7 - CVE-2025-47910 and CVE-2025-47906
- Bump github.com/containers/podman/v5 from 5.6.1 to 5.6.2
- Doc update - Adding Windows installation via WinGet package manager