### PR TITLE
Bump 1.10.0

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	appVersion = "1.10.0"
+	appVersion = "1.11.0-dev"
 )
 
 // versionCmd represents the version command.

--- a/podman-tui.spec.rpkg
+++ b/podman-tui.spec.rpkg
@@ -15,8 +15,8 @@
 %global git0 https://%{import_path}
 
 Name: podman-tui
-Version: 1.10.0
-Release: 1%{?dist}
+Version: 1.11.0
+Release: dev.1%{?dist}
 Summary: Podman Terminal User Interface
 License: ASL 2.0
 URL: %{git0}
@@ -60,6 +60,8 @@ install -p ./bin/%{name} %{buildroot}%{_bindir}
 %{_bindir}/%{name}
 
 %changelog
+* Mon Dec 22 2025 Navid Yaghoobi <navidys@fedoraproject.org> 1.11.0-dev-1
+
 * Mon Dec 22 2025 Navid Yaghoobi <navidys@fedoraproject.org> 1.10.0-1
 - Bugfix for exec terminal del and delete key input
 - Bugfix for exec terminal enter key input


### PR DESCRIPTION
- Bugfix for exec terminal del and delete key input
- Bugfix for exec terminal enter key input
- Bats skip tests feature
- Update README.md to include docs on running the socket on non systemd distros
- Update install.md to include Nix installation
- Bump podman to v5.7.1
- Bump golang.org/x/crypto from 0.43.0 to 0.46.0
- Bump golang.org/x/crypto from 0.42.0 to 0.43.0
- Bump github.com/spf13/cobra from 1.10.1 to 1.10.2
- Bump github.com/gdamore/tcell/v2 from 2.12.1 to 2.13.4
- Bump github.com/gdamore/tcell/v2 from 2.10.0 to 2.12.1
- Bump github.com/gdamore/tcell/v2 from 2.9.0 to 2.10.0
- Bump actions/checkout from 5 to 6