### PR TITLE
fix(dialogs): prevent duplicate command-menu shortcut keys

### DIFF
--- a/ui/dialogs/command.go
+++ b/ui/dialogs/command.go
@@ -367,11 +367,15 @@ func makeShortcuts(options [][]string) []rune {
 
 		if assigned := findUnused(cands, used); assigned != 0 {
 			shortcuts[i] = assigned
+			used[assigned] = true
 
 			continue
 		}
 
-		shortcuts[i] = findAlphaFallback(used)
+		if fallback := findAlphaFallback(used); fallback != 0 {
+			shortcuts[i] = fallback
+			used[fallback] = true
+		}
 	}
 
 	return shortcuts

--- a/ui/dialogs/command_test.go
+++ b/ui/dialogs/command_test.go
@@ -112,3 +112,23 @@ var _ = Describe("command dialog", Ordered, func() {
 		cmdDialogApp.Stop()
 	})
 })
+
+var _ = Describe("command dialog shortcuts", func() {
+	It("never assigns duplicate shortcut keys", func() {
+		options := [][]string{
+			{"attach", ""}, {"checkpoint", ""}, {"commit", ""}, {"create", ""},
+			{"diff", ""}, {"exec", ""}, {"healthcheck", ""}, {"inspect", ""},
+			{"kill", ""}, {"logs", ""}, {"pause", ""}, {"port", ""},
+			{"prune", ""}, {"rename", ""}, {"restore", ""}, {"rm", ""},
+			{"run", ""}, {"start", ""}, {"stats", ""}, {"stop", ""},
+			{"top", ""}, {"unpause", ""},
+		}
+		dialog := NewCommandDialog(options)
+		seen := map[rune]bool{}
+		for _, s := range dialog.shortcuts {
+			Expect(s).NotTo(Equal(rune(0)), "every command should get a shortcut")
+			Expect(seen[s]).To(BeFalse(), "duplicate shortcut key: %c", s)
+			seen[s] = true
+		}
+	})
+})


### PR DESCRIPTION
## Problem

The command menu (e.g. the containers menu) could assign the **same** shortcut key to multiple commands. On the containers menu this surfaced as both `port` and `stop` (and `commit`, `restore`) all mapping to `o`, making those shortcuts ambiguous / unusable.

## Root cause

In `ui/dialogs/command.go`, `makeShortcuts` runs two passes:

1. First pass assigns each command's preferred candidate letter and records it in the `used` map — correctly.
2. Second pass handles commands whose preferred letter was already taken, falling back via `findUnused` / `findAlphaFallback`. **This pass assigned fallback letters but never recorded them in the `used` map**, so the same letter was handed out again to the next command.

On the containers command list the collisions were:

| command   | assigned (before) |
|-----------|-------------------|
| `commit`  | `o`               |
| `port`    | `o` (dup)         |
| `restore` | `o` (dup)         |
| `stop`    | `o` (dup)         |
| `create`  | `b`               |
| `stats`   | `b` (dup)         |
| `prune`   | `n`               |
| `run`     | `n` (dup)         |

## Fix

Mark each second-pass assignment as used (`used[assigned] = true` / `used[fallback] = true`) so the allocator never re-hands a letter that's already been assigned.

After the fix every command on the containers menu gets a unique shortcut:

```
attach -> a    port   -> f
commit -> o    restore-> g
stop   -> v    ...
```

## Tests

Adds a regression test in `ui/dialogs/command_test.go` asserting no duplicate shortcut keys over the full containers command list. Existing `ui/dialogs` tests still pass.